### PR TITLE
Fix some tail bugs

### DIFF
--- a/src/tail.c
+++ b/src/tail.c
@@ -1626,9 +1626,7 @@ tail_forever_inotify (int wd, struct File_spec *f, size_t n_files,
              been clobbered via a rename), when tailing by NAME, we
              must continue to watch the file.  It's only when following
              by file descriptor that we must remove the watch.  */
-          if ((ev->mask & IN_DELETE_SELF)
-              || ((ev->mask & IN_MOVE_SELF)
-                  && follow_mode == Follow_descriptor))
+          if (ev->mask & IN_DELETE_SELF)
             {
               inotify_rm_watch (wd, fspec->wd);
               hash_delete (wd_to_name, fspec);

--- a/src/tail.c
+++ b/src/tail.c
@@ -1584,7 +1584,12 @@ tail_forever_inotify (int wd, struct File_spec *f, size_t n_files,
 
           /* Remove 'fspec' and re-add it using 'new_fd' as its key.  */
           hash_delete (wd_to_name, fspec);
-          fspec->wd = new_wd;
+
+		  if (new_wd != fspec->wd)
+			{
+			  inotify_rm_watch(wd, f[j].wd);
+			  fspec->wd = new_wd;
+			}
 
           /* If the file was moved then inotify will use the source file wd for
              the destination file.  Make sure the key is not present in the


### PR DESCRIPTION
run below script (using inotify)

```shell
let count=0; echo $count>>a.log; tail -F a.log & while true; do mv a.log a.log.$count; let count=count+1; echo $count>>a.log; done
```

When the number of generated file is over the "/proc/sys/fs/inotify/max_user_watches", tail can't watch new a.log file.