### PR TITLE
doc: clarify how cp behaves with default acls

### DIFF
--- a/doc/coreutils.texi
+++ b/doc/coreutils.texi
@@ -8052,9 +8052,11 @@ Using @option{--preserve} with no @var{attribute_list} is equivalent
 to @option{--preserve=mode,ownership,timestamps}.
 
 In the absence of this option, the permissions of existing destination
-files are unchanged, while each new file is created with the
-mode bits of the corresponding source file, minus the bits set in the
-umask and minus the set-user-ID and set-group-ID bits.
+files are unchanged.  Each new file is created with the mode of the
+corresponding source file minus the set-user-ID, set-group-ID, and
+sticky bits as the create mode; the operating system then applies either
+the umask or a default acl, possibly resulting in a more restrictive
+file mode.
 @xref{File permissions}.
 
 @item --no-preserve=@var{attribute_list}


### PR DESCRIPTION
The default behavior of cp in the presence of default acls is ill-documented; clarify. (I have explained this here as well: http://debbugs.gnu.org/cgi/bugreport.cgi?bug=18748#36)

* doc/coreutils.texi: Mention that when copying files without preserving
permissions, the umask or a default acl affect the mode of new files.