### PR TITLE
Docs: Inform about binary prefixes in helptexts

### DIFF
--- a/doc/coreutils.texi
+++ b/doc/coreutils.texi
@@ -697,6 +697,8 @@ one of the following multiplicative suffixes:
 @samp{G}  => 1024*1024*1024 (GibiBytes)
 @end example
 and so on for @samp{T}, @samp{P}, @samp{E}, @samp{Z}, and @samp{Y}.
+Binary prefixes can be used, too: @samp{KiB} =@samp{K}, @samp{MiB} =@samp{M},
+@samp{GiB} =@samp{G}, and so on.
 @end macro
 
 @c FIXME: same as above, but no ``blocks'' line.
@@ -712,6 +714,8 @@ one of the following multiplicative suffixes:
 @samp{G}  => 1024*1024*1024 (GibiBytes)
 @end example
 and so on for @samp{T}, @samp{P}, @samp{E}, @samp{Z}, and @samp{Y}.
+Binary prefixes can be used, too: @samp{KiB} =@samp{K}, @samp{MiB} =@samp{M},
+@samp{GiB} =@samp{G}, and so on.
 @end macro
 
 @cindex common options

--- a/doc/coreutils.texi
+++ b/doc/coreutils.texi
@@ -697,8 +697,8 @@ one of the following multiplicative suffixes:
 @samp{G}  => 1024*1024*1024 (GibiBytes)
 @end example
 and so on for @samp{T}, @samp{P}, @samp{E}, @samp{Z}, and @samp{Y}.
-Binary prefixes can be used, too: @samp{KiB} =@samp{K}, @samp{MiB} =@samp{M},
-@samp{GiB} =@samp{G}, and so on.
+Binary prefixes can be used, too: @samp{KiB}=@samp{K}, @samp{MiB}=@samp{M},
+@samp{GiB}=@samp{G}, and so on.
 @end macro
 
 @c FIXME: same as above, but no ``blocks'' line.
@@ -714,8 +714,8 @@ one of the following multiplicative suffixes:
 @samp{G}  => 1024*1024*1024 (GibiBytes)
 @end example
 and so on for @samp{T}, @samp{P}, @samp{E}, @samp{Z}, and @samp{Y}.
-Binary prefixes can be used, too: @samp{KiB} =@samp{K}, @samp{MiB} =@samp{M},
-@samp{GiB} =@samp{G}, and so on.
+Binary prefixes can be used, too: @samp{KiB}=@samp{K}, @samp{MiB}=@samp{M},
+@samp{GiB}=@samp{G}, and so on.
 @end macro
 
 @cindex common options

--- a/src/dd.c
+++ b/src/dd.c
@@ -592,9 +592,9 @@ Copy a file, converting and formatting according to the operands.\n\
       fputs (_("\
 \n\
 N and BYTES may be followed by the following multiplicative suffixes:\n\
-c =1, w =2, b =512, kB =1000, K =1024, MB =1000*1000, M =1024*1024, xM =M,\n\
-GB =1000*1000*1000, G =1024*1024*1024, and so on for T, P, E, Z, Y.\n\
-Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
+c=1, w=2, b=512, kB=1000, K=1024, MB=1000*1000, M=1024*1024, xM=M,\n\
+GB=1000*1000*1000, G=1024*1024*1024, and so on for T, P, E, Z, Y.\n\
+Binary prefixes can be used, too: KiB=K, MiB=M, GiB=G, and so on.\n\
 \n\
 Each CONV symbol may be:\n\
 \n\

--- a/src/dd.c
+++ b/src/dd.c
@@ -594,6 +594,7 @@ Copy a file, converting and formatting according to the operands.\n\
 N and BYTES may be followed by the following multiplicative suffixes:\n\
 c =1, w =2, b =512, kB =1000, K =1024, MB =1000*1000, M =1024*1024, xM =M,\n\
 GB =1000*1000*1000, G =1024*1024*1024, and so on for T, P, E, Z, Y.\n\
+Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
 \n\
 Each CONV symbol may be:\n\
 \n\

--- a/src/head.c
+++ b/src/head.c
@@ -141,6 +141,7 @@ With more than one FILE, precede each with a header giving the file name.\n\
 NUM may have a multiplier suffix:\n\
 b 512, kB 1000, K 1024, MB 1000*1000, M 1024*1024,\n\
 GB 1000*1000*1000, G 1024*1024*1024, and so on for T, P, E, Z, Y.\n\
+Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
 "), stdout);
       emit_ancillary_info (PROGRAM_NAME);
     }

--- a/src/head.c
+++ b/src/head.c
@@ -141,7 +141,7 @@ With more than one FILE, precede each with a header giving the file name.\n\
 NUM may have a multiplier suffix:\n\
 b 512, kB 1000, K 1024, MB 1000*1000, M 1024*1024,\n\
 GB 1000*1000*1000, G 1024*1024*1024, and so on for T, P, E, Z, Y.\n\
-Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
+Binary prefixes can be used, too: KiB=K, MiB=M, GiB=G, and so on.\n\
 "), stdout);
       emit_ancillary_info (PROGRAM_NAME);
     }

--- a/src/od.c
+++ b/src/od.c
@@ -417,7 +417,7 @@ BYTES is hex with 0x or 0X prefix, and may have a multiplier suffix:\n\
   MB   1000*1000\n\
   M    1024*1024\n\
 and so on for G, T, P, E, Z, Y.\n\
-Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
+Binary prefixes can be used, too: KiB=K, MiB=M, GiB=G, and so on.\n\
 "), stdout);
       emit_ancillary_info (PROGRAM_NAME);
     }

--- a/src/od.c
+++ b/src/od.c
@@ -417,6 +417,7 @@ BYTES is hex with 0x or 0X prefix, and may have a multiplier suffix:\n\
   MB   1000*1000\n\
   M    1024*1024\n\
 and so on for G, T, P, E, Z, Y.\n\
+Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
 "), stdout);
       emit_ancillary_info (PROGRAM_NAME);
     }

--- a/src/stdbuf.c
+++ b/src/stdbuf.c
@@ -111,7 +111,7 @@ If MODE is '0' the corresponding stream will be unbuffered.\n\
       fputs (_("\n\
 Otherwise MODE is a number which may be followed by one of the following:\n\
 KB 1000, K 1024, MB 1000*1000, M 1024*1024, and so on for G, T, P, E, Z, Y.\n\
-Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
+Binary prefixes can be used, too: KiB=K, MiB=M, GiB=G, and so on.\n\
 In this case the corresponding stream will be fully buffered with the buffer\n\
 size set to MODE bytes.\n\
 "), stdout);

--- a/src/stdbuf.c
+++ b/src/stdbuf.c
@@ -111,6 +111,7 @@ If MODE is '0' the corresponding stream will be unbuffered.\n\
       fputs (_("\n\
 Otherwise MODE is a number which may be followed by one of the following:\n\
 KB 1000, K 1024, MB 1000*1000, M 1024*1024, and so on for G, T, P, E, Z, Y.\n\
+Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
 In this case the corresponding stream will be fully buffered with the buffer\n\
 size set to MODE bytes.\n\
 "), stdout);

--- a/src/system.h
+++ b/src/system.h
@@ -595,7 +595,7 @@ emit_size_note (void)
   fputs (_("\n\
 The SIZE argument is an integer and optional unit (example: 10K is 10*1024).\n\
 Units are K,M,G,T,P,E,Z,Y (powers of 1024) or KB,MB,... (powers of 1000).\n\
-Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
+Binary prefixes can be used, too: KiB=K, MiB=M, GiB=G, and so on.\n\
 "), stdout);
 }
 

--- a/src/system.h
+++ b/src/system.h
@@ -595,6 +595,7 @@ emit_size_note (void)
   fputs (_("\n\
 The SIZE argument is an integer and optional unit (example: 10K is 10*1024).\n\
 Units are K,M,G,T,P,E,Z,Y (powers of 1024) or KB,MB,... (powers of 1000).\n\
+Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
 "), stdout);
 }
 

--- a/src/tail.c
+++ b/src/tail.c
@@ -315,6 +315,7 @@ With more than one FILE, precede each with a header giving the file name.\n\
 NUM may have a multiplier suffix:\n\
 b 512, kB 1000, K 1024, MB 1000*1000, M 1024*1024,\n\
 GB 1000*1000*1000, G 1024*1024*1024, and so on for T, P, E, Z, Y.\n\
+Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
 \n\
 "), stdout);
      fputs (_("\

--- a/src/tail.c
+++ b/src/tail.c
@@ -315,7 +315,7 @@ With more than one FILE, precede each with a header giving the file name.\n\
 NUM may have a multiplier suffix:\n\
 b 512, kB 1000, K 1024, MB 1000*1000, M 1024*1024,\n\
 GB 1000*1000*1000, G 1024*1024*1024, and so on for T, P, E, Z, Y.\n\
-Binary prefixes can be used, too: KiB =K, MiB =M, GiB =G, and so on.\n\
+Binary prefixes can be used, too: KiB=K, MiB=M, GiB=G, and so on.\n\
 \n\
 "), stdout);
      fputs (_("\


### PR DESCRIPTION
One can use binary prefixes (e.g. `Mi`, like in `MiB`) with `dd` command, but that is not written in the help text.
I just found out because I wanted to add support for binary prefixes since I did not know they are already supported.
It's a hidden, but valuable feature, since I think, that `M` is binary is hard to remember and can easily lead to confusion. Much clearer to use `Mi`. "M" is mentioned only for backwards compatibility.

I have send an email with the patch file to bug-coreutils@gnu.org.

Result is
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32242

Somehow complicated workflow.