### PR TITLE
fix cases where insecure randomness could be used

### DIFF
--- a/gl/lib/randint.c
+++ b/gl/lib/randint.c
@@ -38,7 +38,7 @@ main (int argc, char **argv)
   randint n = strtoumax (argv[1], NULL, 10);
   randint choices = strtoumax (argv[2], NULL, 10);
   char const *name = argv[3];
-  struct randint_source *ints = randint_all_new (name, SIZE_MAX);
+  struct randint_source *ints = randint_all_new (name);
 
   for (i = 0; i < n; i++)
     printf ("%"PRIuMAX"\n", randint_choose (ints, choices));
@@ -81,9 +81,9 @@ randint_new (struct randread_source *source)
    unsuccessful.  */
 
 struct randint_source *
-randint_all_new (char const *name, size_t bytes_bound)
+randint_all_new (char const *name)
 {
-  struct randread_source *source = randread_new (name, bytes_bound);
+  struct randread_source *source = randread_new (name);
   return (source ? randint_new (source) : NULL);
 }
 

--- a/gl/lib/randint.h
+++ b/gl/lib/randint.h
@@ -33,7 +33,7 @@ typedef uintmax_t randint;
 struct randint_source;
 
 struct randint_source *randint_new (struct randread_source *);
-struct randint_source *randint_all_new (char const *, size_t);
+struct randint_source *randint_all_new (char const *);
 struct randread_source *randint_get_source (struct randint_source const *)
   _GL_ATTRIBUTE_PURE;
 randint randint_genmax (struct randint_source *, randint genmax);

--- a/gl/lib/randread.h
+++ b/gl/lib/randread.h
@@ -24,7 +24,7 @@
 
 struct randread_source;
 
-struct randread_source *randread_new (char const *, size_t);
+struct randread_source *randread_new (char const *);
 void randread (struct randread_source *, void *, size_t);
 void randread_set_handler (struct randread_source *, void (*) (void const *));
 void randread_set_handler_arg (struct randread_source *, void const *);

--- a/src/shred.c
+++ b/src/shred.c
@@ -1252,7 +1252,7 @@ main (int argc, char **argv)
       usage (EXIT_FAILURE);
     }
 
-  randint_source = randint_all_new (random_source, SIZE_MAX);
+  randint_source = randint_all_new (random_source);
   if (! randint_source)
     die (EXIT_FAILURE, errno, "%s", quotef (random_source));
   atexit (clear_random_data);

--- a/src/shuf.c
+++ b/src/shuf.c
@@ -536,11 +536,8 @@ main (int argc, char **argv)
      input is small and if not repeating.  */
   size_t ahead_lines = repeat || head_lines < n_lines ? head_lines : n_lines;
 
-  randint_source = randint_all_new (random_source,
-                                    (use_reservoir_sampling || repeat
-                                     ? SIZE_MAX
-                                     : randperm_bound (ahead_lines, n_lines)));
-  if (! randint_source)
+  randint_source = randint_all_new(random_source);
+  if (!randint_source)
     die (EXIT_FAILURE, errno, "%s", quotef (random_source));
 
   if (use_reservoir_sampling)

--- a/src/sort.c
+++ b/src/sort.c
@@ -2095,7 +2095,7 @@ static void
 random_md5_state_init (char const *random_source)
 {
   unsigned char buf[MD5_DIGEST_SIZE];
-  struct randread_source *r = randread_new (random_source, sizeof buf);
+  struct randread_source *r = randread_new (random_source);
   if (! r)
     sort_die (_("open failed"), random_source);
   randread (r, buf, sizeof buf);


### PR DESCRIPTION
Apologies for submitting on GitHub, it's so much more convenient. I will understand if no one sees this because I didn't follow the guidelines.

Justification:

- The existing code is dangerous because it can silently fail to seed the random number generator securely, either when `fopen()` fails or when `read()` returns fewer bytes than requested, which can happen if the call is interrupted by an interrupt. This is important for utilities like `shred` where cryptographic-quality randomness is important.
- I removed the `bytes_bound` stuff because it didn't seem necessary anywhere it was used, and if `get_nonce` is ever called with `bytes_bound < bufsize`, then part of ISAAC's initial state will contain timestamps/PIDs, so it will not be uniformly random. Usually, stream ciphers like ISAAC require their initial state to be uniformly random, otherwise there will be statistical biases in the early output.

I have not tested all the utilities this affects.

(Full disclosure is appropriate in this case because any damage has already been done, fixing the problem in secret would not stop any attacks, but disclosing might encourage users to stop using the dangerous code and upgrade.)