### PR TITLE
tail: ignore any ESPIPE errors when a pipe reappears

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -40,6 +40,7 @@ GNU coreutils NEWS                                    -*- outline -*-
 
   stat and tail now know about the "vboxsf" file system type.
   stat -f -c%T now reports the file system type, and tail -f uses polling.
+  When a pipe reappears, tail no longer fails with `cannot seek to offset 0: Illegal seek` but instead correctly ignores any `ESPIPE` error.
 
 
 * Noteworthy changes in release 8.32 (2020-03-05) [stable]

--- a/src/tail.c
+++ b/src/tail.c
@@ -500,6 +500,9 @@ xlseek (int fd, off_t offset, int whence, char const *filename)
   if (0 <= new_offset)
     return new_offset;
 
+  if (errno == ESPIPE)
+    return new_offset;
+
   s = offtostr (offset, buf);
   switch (whence)
     {


### PR DESCRIPTION
Given `/tmp/test` is a pipe that is regularly disappearing and reappearing,
when running `tail -F -n +1 /tmp/test`
the behavior changed from: 
```
tail: '/tmp/test' has become inaccessible: No such file or directory
tail: '/tmp/test' has appeared;  following new file
tail: /tmp/test: cannot seek to offset 0: Illegal seek
```

to:

```
tail: '/tmp/test' has become inaccessible: No such file or directory
tail: '/tmp/test' has appeared;  following new file
[new content]
```