### PR TITLE
bootstrap.conf: add wget to build prerequisites

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -369,6 +369,7 @@ patch      -
 perl       5.5
 rsync      -
 tar        -
+wget       -
 xz         -
 "
 


### PR DESCRIPTION
Add wget as a build prerequisites to avoid the following error :

```
Submodule path 'gnulib': checked out 'e2bd71038406e06eeedb4139cb61f3b43aeb3b2f'
./bootstrap: getting translations into po/.reference for coreutils...
./bootstrap: 1: eval: wget: not found
```