### PR TITLE
Fix Uninitialized Variable Bug in copy.c

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -2202,8 +2202,8 @@ copy_internal (char const *src_name, char const *dst_name,
 {
   struct stat src_sb;
   struct stat dst_sb;
-  mode_t src_mode IF_LINT ( = 0);
-  mode_t dst_mode IF_LINT ( = 0);
+  mode_t src_mode = 0;
+  mode_t dst_mode = 0;
   mode_t dst_mode_bits;
   mode_t omitted_permissions;
   bool restore_dst_mode = false;


### PR DESCRIPTION
## Bug Summary

The `src_mode` variable in `copy_internal()` function is declared with conditional initialization using `IF_LINT` macro, but is used extensively throughout the function without guaranteed initialization, leading to potential use of uninitialized values.

## Root Cause

Variable declared as `mode_t src_mode IF_LINT (= 0);` (line 1892) is only initialized inside conditional block (lines 1918-1931). When condition is false, `src_mode` contains garbage value.

## Trigger Conditions

`rename_errno == 0 AND x->last_file == true` (condition becomes false)
`rename_errno != 0 AND rename_errno == EEXIST AND x->interactive == I_ALWAYS_NO` (condition becomes false)

This can lead to incorrect file type detection, wrong copy/move behavior and potential security issues.

The fix initializes src_mode to 0 (invalid file type), ensuring safe behavior when the conditional initialization is skipped. The existing code already handles unknown file types appropriately, making this a minimal and safe change.
