### PR TITLE
tests: Add test for csplit trying to write to symlink to /dev/full

### DIFF
--- a/tests/csplit/csplit-io-err-2.sh
+++ b/tests/csplit/csplit-io-err-2.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Ensure we handle i/o errors correctly in csplit via /dev/full
+
+# Copyright (C) 2015-2025 Free Software Foundation, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
+print_ver_ csplit
+
+cp -sf /dev/full xx01 || skip_ '/dev/full is required'
+
+# Ensure error messages are in English
+LC_ALL=C
+export LC_ALL
+
+# Get the wording of the OS-dependent ENOSPC message
+returns_ 1 seq 1 >/dev/full 2>msgt || framework_failure_
+sed 's/seq: write error: //' msgt > msg || framework_failure_
+
+# Create the expected error message
+{ printf "%s" "csplit: xx01: " ; cat msg ; } > exp || framework_failure_
+
+# the 'csplit' command should fail with exit code 1
+seq 2 | returns_ 1 csplit - 1 2> err || fail=1
+# csplit should cleanup broken files
+test -e xx01 && fail=1
+
+# Ensure we got the expected error message
+compare exp err || fail=1
+
+Exit $fail

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -317,6 +317,7 @@ all_tests =					\
   tests/csplit/csplit-1000.sh			\
   tests/csplit/csplit-heap.sh			\
   tests/csplit/csplit-io-err.sh			\
+  tests/csplit/csplit-io-err-2.sh			\
   tests/csplit/csplit-suppress-matched.pl	\
   tests/date/date-debug.sh			\
   tests/date/date-ethiopia.sh			\


### PR DESCRIPTION
Has slightly different error with `csplit-io-err.sh` and different framework dependency.