### PR TITLE
tests: stty: add require_controlling_input_terminal_ to bad-speed test

### DIFF
--- a/tests/stty/bad-speed.sh
+++ b/tests/stty/bad-speed.sh
@@ -19,6 +19,7 @@
 
 . "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
 print_ver_ stty
+require_controlling_input_terminal_
 require_gcc_shared_
 
 # Replace each cfsetispeed call with a call to these stubs.


### PR DESCRIPTION
The bad-speed test runs `stty ispeed 9600` without a `--file` argument, which requires a controlling terminal. Without it, stty fails early with "Inappropriate ioctl for device" before reaching cfsetispeed, causing the test to skip with a misleading "LD_PRELOAD interception failed" message.

Add `require_controlling_input_terminal_` to match the other stty tests (stty.sh, stty-pairs.sh, stty-row-col.sh, stty-invalid.sh) which all require a controlling terminal.