### PR TITLE
tests: cp a b --debug > /dev/full copies a

### DIFF
--- a/tests/cp/debug.sh
+++ b/tests/cp/debug.sh
@@ -29,4 +29,7 @@ touch file.cp || framework_failure_
 cp --debug --update=none file file.cp >cp.out || fail=1
 grep 'skipped' cp.out || fail=1
 
+returns_ 1 cp file exist --debug > /dev/full || fail=1
+test -e exist || fail=1
+
 Exit $fail


### PR DESCRIPTION
Instead of
```
thread 'main' (1690) panicked at /usr/lib/rustlib/src/rust/library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: No space left on device (os error 28)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```