### PR TITLE
Verify that -f and -i override each other, last one wins.

### DIFF
--- a/tests/ln/misc.sh
+++ b/tests/ln/misc.sh
@@ -128,5 +128,26 @@ done
 ln foo '' 2> /dev/null
 
 # ===================================================
+# Verify that -f and -i override each other, last one wins.
+
+# -sif: force should win (no prompt, overwrite)
+rm -f a b
+touch a b || framework_failure_
+ln -sif a b || fail=1
+test -L b || fail=1
+
+# -sfi: interactive should win; answering "n" should keep b unchanged
+rm -f a b
+touch a b || framework_failure_
+echo n | ln -sfi a b || :
+test -L b && fail=1
+
+# -sfi: interactive should win; answering "y" should create symlink
+rm -f a b
+touch a b || framework_failure_
+echo y | ln -sfi a b || fail=1
+test -L b || fail=1
+
+# ===================================================
 
 Exit $fail


### PR DESCRIPTION
Identified here:
<https://github.com/uutils/coreutils/pull/11129>

* tests/ln/misc.sh: Add the check.
