### PR TITLE
tests: mktemp: ensure mktemp does not depend on getrandom and ASLR

### DIFF
--- a/tests/local.mk
+++ b/tests/local.mk
@@ -283,6 +283,7 @@ all_tests =					\
   tests/od/od-endian.sh				\
   tests/od/od-float.sh				\
   tests/mktemp/bad-unicode.sh			\
+  tests/mktemp/mktemp-misc.sh			\
   tests/mktemp/mktemp.pl			\
   tests/misc/arch.sh				\
   tests/pr/bounded-memory.sh			\

--- a/tests/mktemp/mktemp-misc.sh
+++ b/tests/mktemp/mktemp-misc.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Test 'mktemp' under specialized situations.
+
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
+print_ver_ mktemp
+uses_strace_
+
+# ensure randomization doesn't depend solely on ASLR
+# Since this is a probabilistic test, we use a long templete...
+mktemp_rand() { setarch -R mktemp -u  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; }
+mktemp_rand >out1 && mktemp_rand >out2 && compare out1 out2 && fail=1
+
+# ensure mktemp does not strongly depend on getrandom
+strace -o /dev/null -e inject=getrandom:error=ENOSYS mktemp -u || fail=1
+
+Exit $fail


### PR DESCRIPTION
- Check that `mktemp -u` does not do same things without ASLR
- Detect https://github.com/uutils/coreutils/issues/11153 

I'm not sure can we do that at `*.pl`...