### PR TITLE
tests: coreutils.sh: ensure utility name is detected at shebang

### DIFF
--- a/tests/misc/coreutils.sh
+++ b/tests/misc/coreutils.sh
@@ -41,4 +41,11 @@ compare exp err || fail=1
 returns_ 1 ./blah --version 2>err || fail=1
 compare exp err || fail=1
 
+# Ensure utility name is detected at shebang
+# This fails if utility name is taken from AT_EXECFN(path of the script)
+echo '#!'"$(command -v coreutils|sed "s|/coreutils|/yes --version|")" > success \
+  || framework_failure_
+
+./success || fail=1
+
 Exit $fail


### PR DESCRIPTION
~Closes #215~
Check that multi-call binary called as shebang detects it's utility name correctly. It fails when the binary tried to detect the name from `AT_EXECFN` (path of the script).

The shebang wrapper's name does not have any actual util's name for the case the binary try to match with `*utility_name` (e.g. uutils).