### PR TITLE
tests, coreutils: ensure multi-call binary is executable from fd

### DIFF
--- a/tests/misc/coreutils.sh
+++ b/tests/misc/coreutils.sh
@@ -38,4 +38,8 @@ compare exp err || fail=1
 returns_ 1 ./blah --version 2>err || fail=1
 compare exp err || fail=1
 
+# Ensure coreutils works with memfd_create on the system execution from fd is allowed
+env -a coreutils /proc/self/fd/3 --coreutils-prog=yes --version 3<"$(command -v coreutils)" \
+  && { env -a yes /proc/self/fd/3 --version 3<"$(command -v coreutils)" || fail=1;}
+
 Exit $fail


### PR DESCRIPTION
`AT_EXECFN` based milti-call binary needs exception for the case.