### PR TITLE
Ensure name of utils are not binary name

### DIFF
--- a/tests/misc/coreutils.sh
+++ b/tests/misc/coreutils.sh
@@ -20,7 +20,12 @@
 . "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
 print_ver_ coreutils
 
-cp -s "$(command -v coreutils)" blah || skip_ 'multicall binary is disabled'
+cp -s "$(command -v coreutils)" blah || {
+  # Ensure name of individual binaries are not binary name
+  ln -s $(command -v yes) "$(command -v yes|sed "s|/yes|/no|")"
+  no --version | grep yes || fail=1
+  Exit $fail
+;}
 
 # Yes outputs all its params so is good to verify argv manipulations
 echo 'y' > exp &&


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/11343
happpens when over-abstructed library was used.