### PR TITLE
tests, od: Ensure od -j1 /dev/null success

### DIFF
--- a/tests/od/od-j.sh
+++ b/tests/od/od-j.sh
@@ -19,6 +19,8 @@
 . "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
 print_ver_ od
 
+od -j1 /dev/null || fail=1
+
 for file in ${srcdir=.}/tests/init.sh /proc/version /sys/kernel/profiling; do
   test -r $file || continue
 


### PR DESCRIPTION
Transfered from https://github.com/uutils/coreutils/issues/11494#issuecomment-4128239553 since uutils's CI passes all `od` tests currently. 