### PR TITLE
tests: improve simple_echo to avoid builddir dependency

### DIFF
--- a/tests/env/env.sh
+++ b/tests/env/env.sh
@@ -21,7 +21,8 @@
 print_ver_ env pwd nice
 
 # A simple shebang program to call "echo" from symlinks like "./-u" or "./--".
-echo "#!$abs_top_builddir/src/echo simple_echo" > simple_echo \
+echo "#!/bin/sh" > simple_echo
+echo "echo simple_echo" >> simple_echo
   || framework_failure_
 chmod a+x simple_echo || framework_failure_
 


### PR DESCRIPTION
Fix simple_echo test to avoid dependency on $abs_top_builddir.

The current implementation relies on an internal echo binary, which may not work correctly outside the build environment and can cause inconsistencies when echo behaves as a multi-call binary.

This change replaces it with a simple shell-based script using /bin/sh and system echo, making the test more portable and reliable.