### PR TITLE
tests, stat: Ensure stat works without mounting /proc

### DIFF
--- a/tests/stat/stat-mount.sh
+++ b/tests/stat/stat-mount.sh
@@ -25,4 +25,9 @@ case "$stat_mnt" in
   *) fail=1;;
 esac
 
+# Ensure stat works without mounting /proc
+if unshare -rm true; then
+  unshare -rm bash -c "mount -t tmpfs tmpfs /proc && stat -c '0%#a' /" || fail=1
+fi
+
 Exit $fail


### PR DESCRIPTION
* tests/stat/stat-mount.sh: Add test case for missing /proc

https://github.com/uutils/coreutils/issues/11731#issuecomment-4223197299