### PR TITLE
tests, cat, yes: Ensure checking size of content of pipe is optional

### DIFF
--- a/tests/cat/splice.sh
+++ b/tests/cat/splice.sh
@@ -69,5 +69,11 @@ if no_pipe true; then
   no_pipe timeout .1 cat /dev/zero >/dev/null
   test $? = 124 || fail=1
 fi
+# Ensure checking size of content of pipe is optional
+no_check_size() { strace -f -o /dev/null -e inject=ioctl:error=ENOSYS "$@"; }
+if no_check_size true; then
+  no_check_size timeout .1 yes >/dev/null
+  test $? = 124 || fail=1
+fi
 
 Exit $fail

--- a/tests/misc/yes.sh
+++ b/tests/misc/yes.sh
@@ -84,5 +84,11 @@ if no_pipe true; then
   no_pipe timeout .1 yes >/dev/null
   test $? = 124 || fail=1
 fi
+# Ensure checking size of content of pipe is optional
+no_check_size() { strace -f -o /dev/null -e inject=ioctl:error=ENOSYS "$@"; }
+if no_check_size true; then
+  no_check_size timeout .1 yes >/dev/null
+  test $? = 124 || fail=1
+fi
 
 Exit $fail


### PR DESCRIPTION
If someone tried to use this for buffering and failed, it should not crush.