### PR TITLE
tests: stat: cover %N escaping of control characters

### DIFF
--- a/tests/stat/stat-fmt.sh
+++ b/tests/stat/stat-fmt.sh
@@ -40,6 +40,19 @@ cat <<\EOF >exp
 EOF
 compare exp out || fail=1
 
+# ensure control characters in file names are escaped by %N
+# using the default shell-escape quoting style.
+nl='
+'
+fname="a${nl}${nl}b${nl}c"
+touch "$fname" || framework_failure_
+stat -c%N "$fname" > out || fail=1
+# contiguous control characters are clumped into one $'...' escape.
+cat <<\EOF >exp
+'a'$'\n\n''b'$'\n''c'
+EOF
+compare exp out || fail=1
+
 # Check the behavior with invalid values of QUOTING_STYLE.
 for style in '' 'abcdef'; do
   QUOTING_STYLE="$style" stat -c%%%N \' > out 2> err || fail=1


### PR DESCRIPTION
The default shell-escape quoting style escapes control characters in file names (e.g. newlines) as $'...' sequences, but no test exercised this; only the single-quote character was covered. referenced here: https://github.com/uutils/coreutils/issues/9925

* tests/stat/stat-fmt.sh: Add a case with a file name containing contiguous and separated newlines.
