### PR TITLE
tests: chown: check --no-dereference on a symlink to a directory

### DIFF
--- a/tests/chown/basic.sh
+++ b/tests/chown/basic.sh
@@ -56,4 +56,15 @@ chown --no-dereference --from=0:1 2:010 slink || fail=1
 # owner/group on the symlink should be changed
 set _ $(ls -n slink); shift; test "$3:$4" = 2:10 || fail=1
 
+# Likewise for a symlink to a directory: --no-dereference must operate
+# on the link itself, not descend into the target directory.
+mkdir d || framework_failure_
+chown 2:10 d || fail=1
+ln -s d dlink || framework_failure_
+chown --no-dereference 0:1 dlink || fail=1
+# owner/group on the symlink should be set
+set _ $(ls -n dlink); shift; test "$3:$4" = 0:1  || fail=1
+# owner/group on the target directory should remain unchanged
+set _ $(ls -dn d);    shift; test "$3:$4" = 2:10 || fail=1
+
 Exit $fail


### PR DESCRIPTION
* tests/chown/basic.sh: Add a case ensuring that "chown --no-dereference" on a symlink to a directory operates on the link itself and does not dereference it to change the owner of the target directory.
* reported here https://github.com/uutils/coreutils/issues/11887
