### PR TITLE
tests: ls: also check a trailing '/.' dereferences a symlink arg

### DIFF
--- a/tests/ls/symlink-slash.sh
+++ b/tests/ls/symlink-slash.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Do dereference a symlink arg if its name is written with a trailing slash.
+# Do dereference a symlink arg if its name is written with a trailing
+# slash, or with a trailing '/.' (both denote the directory itself).
 
 # Copyright (C) 1999-2026 Free Software Foundation, Inc.
 
@@ -25,6 +26,11 @@ ln -s dir symlink || framework_failure_
 set -- $(ls -l symlink/)
 
 # Prior to fileutils-4.0k, the following would have output '... symlink -> dir'.
+test "$*" = 'total 0' && : || fail=1
+
+# A path ending in '/.' refers to the directory itself, so it must be
+# dereferenced and its (empty) contents listed, not the symlink shown.
+set -- $(ls -l symlink/.)
 test "$*" = 'total 0' && : || fail=1
 
 Exit $fail


### PR DESCRIPTION
* tests/ls/symlink-slash.sh: A symlink-to-directory argument written as 'symlink/.' denotes the directory itself, just like a trailing slash, so 'ls -l symlink/.' must list the directory contents rather than show the symlink.
See https://github.com/uutils/coreutils/issues/7873 and https://github.com/uutils/coreutils/issues/6467
