### PR TITLE
tests: split: reject excessively large suffix lengths

### DIFF
--- a/tests/split/suffix-length.sh
+++ b/tests/split/suffix-length.sh
@@ -73,4 +73,10 @@ rm -f x*
 returns_ 1 split -a2 -n1000 < /dev/null || fail=1
 test -f xaa && fail=1
 
+# Ensure that an excessively large suffix length fails gracefully,
+# rather than crashing or hanging.
+rm -f x*
+returns_ 1 split -a 66542562175252 in || fail=1
+test -f xaa && fail=1
+
 Exit $fail


### PR DESCRIPTION
* tests/split/suffix-length.sh: Ensure that a pathologically large -a/--suffix-length value fails gracefully rather than crashing or hanging.
reported https://github.com/uutils/coreutils/pull/12609
