### PR TITLE
tests: sort: cover punctuation weight in locale collation

### DIFF
--- a/tests/sort/sort-locale.sh
+++ b/tests/sort/sort-locale.sh
@@ -46,6 +46,9 @@ export LC_ALL=$LOCALE_FR_UTF8
 if test "$(locale charmap 2>/dev/null)" = UTF-8; then
   check_hard_collate 'aaé' 'aaf'  # é comes before f
   check_hard_collate 'aéY' "$(printf 'ae\314\201Z')"  # NFC/NFD é are equal
+  check_hard_collate 'file1' 'file-2'  # '-' has a minimal weight, so the
+                                       # digits decide: file1 before file-2,
+                                       # the opposite of the C/byte order
 fi
 
 Exit $fail


### PR DESCRIPTION
* tests/sort/sort-locale.sh: In a UTF-8 locale '-' carries a minimal (shifted) weight, so 'file1' sorts before 'file-2' even though '-' precedes '1' in the C/byte order.  This is the opposite of the C locale result, so it also exercises the differs-from-C path. Identified here: https://github.com/uutils/coreutils/pull/12677
