### PR TITLE
unexpand: fix heap overflow when a wide blank overshoots a tab stop

### DIFF
--- a/src/unexpand.c
+++ b/src/unexpand.c
@@ -201,7 +201,7 @@ unexpand (void)
                         {
                           column += c32width (g.ch);
 
-                          if (! (prev_blank && column == next_tab_column))
+                          if (! (prev_blank && column >= next_tab_column))
                             {
                               /* It is not yet known whether the pending blanks
                                  will be replaced by tabs.  */

--- a/tests/unexpand/mb.sh
+++ b/tests/unexpand/mb.sh
@@ -169,4 +169,13 @@ for mb_mul in 4 6; do
   test "$ret" = 1 || test "$ret" = 0 || { cat err; fail=1; }
 done
 
+# A blank whose display width exceeds the tab distance must not overrun
+# the pending-blank buffer.  With -t1 every column is a tab stop, so a
+# width-2 ideographic space steps over the stop without landing on it;
+# the run of blanks then grew pending_blank without bound.
+ideo_space=$(env printf '\u3000')
+{ yes "$ideo_space" | head -n 40000 | tr -d '\n'; echo; } |
+  unexpand -t1 >out 2>err; ret=$?
+test "$ret" = 0 || { cat err; fail=1; }
+
 Exit $fail


### PR DESCRIPTION
On a non-glibc libc `c32issep()` decides "blank" from `c32isspace()`
rather than the blank class, so U+3000 IDEOGRAPHIC SPACE is a blank while
keeping its display width of 2:

    U+3000 IDEOGRAPHIC SP  isspace=1 isblank=0 wcwidth=2

`unexpand()` collapses a run of blanks into `pending_blank`, which is only
sized for `max_column_width` columns.  The run stops growing when column
reaches the next tab stop:

    column += c32width (g.ch);
    if (! (prev_blank && column == next_tab_column))
      { ...; memcpy (pending_blank + pending, ...); continue; }

With `-t1` the next stop is always column+1.  A width-2 blank moves column
by 2 and steps over it, so the equality never holds.  The run never
resets and `pending_blank` overruns its allocation.  A line of ideographic
spaces then corrupts the heap:

    { yes "$(printf '　')" | head -n200000 | tr -d '\n'; } | unexpand -t1

Found while running unexpand over multibyte input on macOS.  The non-blank
branch already clamps odd widths; the blank branch trusted the exact hit.
Comparing with `>=` treats an overshoot like a landing.  Width-1 input
still meets every stop exactly, so it stays the same.
