### PR TITLE
cut: fix out-of-bounds read with a multi-byte field delimiter

### DIFF
--- a/src/cut.c
+++ b/src/cut.c
@@ -89,8 +89,9 @@ static bool complement;
 /* The delimiter character for multibyte field mode.  */
 static mcel_t delim_mcel;
 
-/* The delimiter bytes.  */
-static char delim_bytes[MCEL_LEN_MAX];
+/* The delimiter bytes, with a spare byte so they stay NUL terminated for
+   use as the strstr needle in find_field_delim.  */
+static char delim_bytes[MCEL_LEN_MAX + 1];
 
 /* The delimiter for each line/record.  */
 static unsigned char line_delim = '\n';

--- a/tests/cut/cut.pl
+++ b/tests/cut/cut.pl
@@ -438,6 +438,11 @@ if ($mb_locale ne 'C')
       # -F in multi-byte locale
       ['mb-F-1', '-F', '2', {IN=>"\xc3\xa9\t\xc3\xbc\n"},
        {OUT=>"\xc3\xbc\n"},
+       {ENV => "LC_ALL=$mb_locale"}],
+
+      # After coreutils-9.11 this read past the end of a buffer on glibc.
+      ['mb-overflow', '-f1', '-d', "\xF0\x9F\x98\x80",
+       {IN=>"a\xF0\x9F\x98\x80b\n"}, {OUT=>"a\n"},
        {ENV => "LC_ALL=$mb_locale"}];
   }
 


### PR DESCRIPTION
Found while running cut with an emoji field delimiter on a glibc box.

    $ printf 'a\xF0\x9F\x98\x80b\n' | cut -d $'\U0001F600' -f1
    # delimiter U+1F600 is the four bytes F0 9F 98 80

The delimiter is kept in delim_bytes, sized MCEL_LEN_MAX (4 here). On
glibc find_field_delim takes the strstr path and treats that array as a
C string:

    char const *match = strstr (p, delim_bytes);

A valid character can be the full MCEL_LEN_MAX bytes, so the four-byte
delimiter fills delim_bytes with nothing left for a terminator. strstr
then keeps reading past the array hunting for a NUL.

I pinned delim_bytes flush against an unmapped page to confirm it: the
strstr inside find_field_delim faults on delim_bytes[4]. The haystack
already keeps a spare byte for its own NUL (bytes_in[IO_BUFSIZE+1], handed
to mbbuf with size-1); the needle never got the same treatment.

Sizing it MCEL_LEN_MAX + 1 puts the terminator back. The zero
initialisation covers the spare byte, and shorter delimiters were
terminated already, so their behaviour is unchanged.