### PR TITLE
tests, nice: Add test for incomplete arg --adj

### DIFF
--- a/tests/nice/nice.sh
+++ b/tests/nice/nice.sh
@@ -123,4 +123,7 @@ fi
 # Ensure large values are clamped
 nice -n $UINTMAX_OFLOW nice || fail=1
 
+# incomplete arg. success with permission denied
+nice --adj -20 true || fail=1
+
 Exit $fail


### PR DESCRIPTION
If `clap-rs` is not used by some reason, the case can be bypassed.
https://github.com/uutils/coreutils/pull/12924#discussion_r3421992963
https://github.com/uutils/coreutils/pull/12924#discussion_r3422007949