### PR TITLE
tests: split: Ensure split write after something is written to stdin

### DIFF
--- a/tests/split/split-io-err.sh
+++ b/tests/split/split-io-err.sh
@@ -35,6 +35,9 @@ test -e xab && fail=1
 # Ensure we got the expected error message
 compare exp err || fail=1
 
+# Ensure no file is created without input
+split < /dev/null || fail=1
+
 rm xaa || framework_failure_
 # Similar for directory
 mkdir xaa || framework_failure_


### PR DESCRIPTION
* tests/split/split-io-err.sh add test case for stdin
https://github.com/uutils/coreutils/issues/12934