### PR TITLE
wc: fix out-of-bounds read for single-byte wide characters

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,11 @@ GNU coreutils NEWS                                    -*- outline -*-
   'uniq -w' no longer overruns the read buffer in multibyte locales.
   [bug introduced in coreutils-9.5]
 
+  'wc' no longer reads past the end of a lookup table in legacy multibyte
+  encodings like Shift-JIS, where a single input byte can decode to a
+  wide character.
+  [bug introduced in coreutils-9.5]
+
 ** Changes in behavior
 
   'ls' -w,--width no longer includes '\n' in the width of a line.

--- a/src/wc.c
+++ b/src/wc.c
@@ -581,7 +581,7 @@ wc (int fd, char const *file_x, struct fstatus *fstatus)
 
                 default:;
                   bool in_word2;
-                  if (single_byte)
+                  if (single_byte && wide_char <= UCHAR_MAX)
                     {
                       linepos += wc_isprint[wide_char];
                       in_word2 = !wc_isspace[wide_char];

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -308,6 +308,7 @@ all_tests =					\
   tests/wc/wc-nbsp.sh				\
   tests/wc/wc-parallel.sh			\
   tests/wc/wc-proc.sh				\
+  tests/wc/wc-sjis.sh				\
   tests/wc/wc-total.sh				\
   tests/cat/cat-E.sh				\
   tests/cat/cat-proc.sh				\

--- a/tests/wc/wc-sjis.sh
+++ b/tests/wc/wc-sjis.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# A single input byte that decodes to a wide character must not overrun
+# wc's byte-indexed isprint/isspace tables.
+
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
+print_ver_ wc printf
+
+# In SHIFT-JIS the bytes 0xA1..0xDF are half-width katakana: each is a
+# single input byte, yet it decodes to U+FF61..U+FF9F, i.e. > UCHAR_MAX.
+# wc indexes its 256-entry wc_isprint[]/wc_isspace[] tables with the
+# decoded value, so before this fix it read past their end and crashed.
+export LC_ALL=ja_JP.SHIFT_JIS
+
+# No distribution ships this locale, so generate it locally if needed.
+if test "$(locale charmap 2>/dev/null)" != SHIFT_JIS; then
+  mkdir locale || framework_failure_
+  localedef --no-archive --no-warnings=ascii \
+    -f SHIFT_JIS -i ja_JP "$PWD/locale/ja_JP.SHIFT_JIS" \
+    >/dev/null 2>&1 || skip_ "SHIFT-JIS locale not available"
+  export LOCPATH="$PWD/locale"
+fi
+
+env printf 'a\xa1b\n' > in || framework_failure_
+
+# 0xA1 is one byte and one non-space character: 1 line, 1 word, 4 bytes.
+wc in > out || fail=1
+printf '1 1 4 in\n' > exp || framework_failure_
+compare exp out || fail=1
+
+# -L reaches the same table through wc_isprint; ensure it too completes.
+wc -L in > /dev/null || fail=1
+
+Exit $fail


### PR DESCRIPTION
Found while running wc over a SHIFT-JIS file.

    $ printf 'a\xA1b\n' | LC_ALL=ja_JP.SHIFT_JIS wc
    Segmentation fault

Same input under ASAN:

    ERROR: AddressSanitizer: SEGV on unknown address 0x... READ memory access
        #0 ... in wc src/wc.c:586
    SUMMARY: AddressSanitizer: SEGV src/wc.c:586 in wc

The multibyte loop keeps a single_byte flag, but it only records that
mbrtoc32 consumed one input byte, not that the value fits in a byte. In
SHIFT-JIS the half-width katakana bytes 0xA1..0xDF are one byte each yet
decode to U+FF61..U+FF9F. wc_isprint and wc_isspace hold 256 entries, so
wc_isprint[wide_char] reads about 65 kB past the end.

Reachable from ordinary file or stdin input: default wc and -w read
wc_isspace, -L and -m read wc_isprint. A normal -O2 build faults too, not
only the ASAN one. Present since the byte-table fast path arrived in 9.5.

Limiting the fast path to wide_char <= UCHAR_MAX sends these characters
through the c32width/c32isspace branch already used for multibyte input.
That stops the over-read and counts them correctly: the katakana is
printable, width 1, non-space.

The new test needs a SHIFT-JIS locale and skips without one.