### PR TITLE
tests: realpath: a trailing slash must not require read permission

### DIFF
--- a/tests/misc/realpath.sh
+++ b/tests/misc/realpath.sh
@@ -111,4 +111,14 @@ else
   test "$out" = ".$nl." || fail=1
 fi
 
+# A trailing slash only requires the operand to be a directory, which is a
+# stat-level check (search permission on the parent). A directory that is
+# searchable but not readable must still resolve, not fail with EACCES.
+if ! uid_is_privileged_; then
+  mkdir noread && chmod a-r noread || framework_failure_
+  test "$(realpath noread/)" = "$(realpath .)/noread" || fail=1
+  test "$(realpath -e noread/)" = "$(realpath .)/noread" || fail=1
+  chmod u+r noread || framework_failure_
+fi
+
 Exit $fail


### PR DESCRIPTION
A trailing slash only asserts that the operand is a directory.  That is a stat-level check, needing search permission on the parent, not read permission on the directory itself.
* tests/misc/realpath.sh: Check that a searchable but unreadable directory still resolves with a trailing slash, with and without -e. found https://github.com/uutils/coreutils/issues/13151

