### PR TITLE
tests: nproc: use command -v nproc instead of abs_top_builddir

### DIFF
--- a/tests/nproc/nproc-quota.sh
+++ b/tests/nproc/nproc-quota.sh
@@ -44,7 +44,7 @@ ROOT=cgroup
   echo 'max 100000' > $ROOT/sys/fs/cgroup/foo/cpu.max  # ignored
 } || framework_failure_
 
-nproc=$abs_top_builddir/src/nproc$EXEEXT
+nproc=$(command -v nproc)
 cp --parents $(ldd $nproc | grep -o '/[^ ]*') $ROOT ||
   skip_ 'Failed to copy nproc libs to chroot'
 cp $nproc $ROOT || framework_failure_


### PR DESCRIPTION
* tests/nproc/nproc-quota.sh: use command -v nproc instead of abs_top_builddir for external usage of tests