### PR TITLE
tests: ls: check that an invalid --tabsize is diagnosed

### DIFF
--- a/tests/ls/ls-misc.pl
+++ b/tests/ls/ls-misc.pl
@@ -349,6 +349,12 @@ my @Tests =
       $rmdir_reg,
       {EXIT => 2},
      ],
+
+     # Negative, non-numeric and fractional --tabsize values are invalid.
+     (map { ["tabsize-invalid-$_", "--tabsize=$_",
+             {ERR => "$prog: invalid tab size: '$_'\n"},
+             {EXIT => 2},
+            ] } qw(-9 zz 0.5)),
     );
 
 umask 022;


### PR DESCRIPTION
* tests/ls/ls-misc.pl (tabsize-negative, tabsize-non-numeric): New tests verifying that a negative or non-numeric --tabsize argument is rejected with "invalid tab size" and exit status 2.
https://github.com/uutils/coreutils/pull/13278
