### PR TITLE
tests: numfmt: check --header does not swallow a following operand

### DIFF
--- a/tests/numfmt/numfmt.pl
+++ b/tests/numfmt/numfmt.pl
@@ -507,6 +507,11 @@ my @Tests =
              {IN_PIPE=>"hello\nworld\n"},
              {OUT=>"hello\nworld"}],
 
+     # --header takes an argument only via '=': a following operand
+     # must not be swallowed as the option's value.
+     ['header-10', '--header 7 8',
+             {OUT=>"7\n8"}],
+
 
      ## human_strtod testing
 


### PR DESCRIPTION
* tests/numfmt/numfmt.pl (header-10): New test verifying that --header, which only accepts an argument via '=', does not consume a following operand as its value.
https://github.com/uutils/coreutils/pull/13273
