### PR TITLE
tests: printf, seq: add tests for large field widths and precisions

### DIFF
--- a/tests/printf/printf.sh
+++ b/tests/printf/printf.sh
@@ -134,4 +134,22 @@ EOF
 compare exp out || fail=1
 compare exp_err err || fail=1
 
+# Ensure large field widths and precisions produce fully padded output
+$prog '%70000d' 1 > out || fail=1
+test "$(wc -c < out)" = 70000 || fail=1
+test "$(tr -d ' ' < out)" = 1 || fail=1
+
+$prog '%500000s' x > out || fail=1
+test "$(wc -c < out)" = 500000 || fail=1
+test "$(tr -d ' ' < out)" = x || fail=1
+
+$prog '%.70000f' 1 > out || fail=1
+test "$(wc -c < out)" = 70002 || fail=1
+test "$(tr -d 0 < out)" = '1.' || fail=1
+
+# Ensure a precision beyond 1000 digits is not truncated
+$prog '%.1000f' 1 > out || fail=1
+test "$(wc -c < out)" = 1002 || fail=1
+test "$(tr -d 0 < out)" = '1.' || fail=1
+
 Exit $fail

--- a/tests/seq/seq-precision.sh
+++ b/tests/seq/seq-precision.sh
@@ -82,4 +82,9 @@ compare exp out || fail=1
 seq 1e$LONG_MIN 2> err || fail=1
 compare /dev/null err || fail=1
 
+# Ensure a large format precision is fully honored
+seq -f '%.70000f' 1 > out || fail=1
+test "$(wc -c < out)" = 70003 || fail=1
+test "$(tr -d 0 < out)" = '1.' || fail=1
+
 Exit $fail


### PR DESCRIPTION
* tests/printf/printf.sh: Ensure a large field width or precision produces fully padded output, and that a precision beyond 1000 digits is not truncated.
* tests/seq/seq-precision.sh: Ensure a large format precision is fully honored.
Found:
https://github.com/uutils/coreutils/pull/13460
