### PR TITLE
tests: numfmt: add tests for overflowing unit sizes

### DIFF
--- a/tests/numfmt/numfmt.pl
+++ b/tests/numfmt/numfmt.pl
@@ -115,6 +115,14 @@ my @Tests =
      ['unit-10', '--to-unit=0 1',
              {ERR => "$prog: invalid unit size: '0'\n"},
              {EXIT => '1'}],
+     # Ensure a unit size whose suffix multiplication overflows uintmax_t
+     # is rejected.  18014398509481984Ki is 2^54 * 2^10 = UINTMAX_MAX + 1.
+     ['unit-11', '--to-unit=18014398509481984Ki 1000',
+             {ERR => "$prog: invalid unit size: '18014398509481984Ki'\n"},
+             {EXIT => '1'}],
+     ['unit-12', '--from-unit='.$limits->{UINTMAX_MAX}.'K 1',
+             {ERR => "$prog: invalid unit size: '$limits->{UINTMAX_MAX}K'\n"},
+             {EXIT => '1'}],
 
      # Test Suffix logic
      ['suf-1', '4000',    {OUT=>'4000'}],


### PR DESCRIPTION
* tests/numfmt/numfmt.pl (@Tests): Add unit-11 and unit-12, ensuring a --to-unit/--from-unit whose suffix multiplication overflows uintmax_t is rejected with "invalid unit size" rather than being wrapped or crashing.
Found:
https://github.com/uutils/coreutils/pull/13484
