### PR TITLE
Rename rm no-preserve-root option to agree-to-system-destruction and add deprecation warning

### DIFF
--- a/src/remove.c
+++ b/src/remove.c
@@ -479,7 +479,23 @@ rm_fts (FTS *fts, FTSENT *ent, struct rm_options const *x)
              is in effect -- default) diagnose and skip it.  */
           if (ROOT_DEV_INO_CHECK (x->root_dev_ino, ent->fts_statp))
             {
-              ROOT_DEV_INO_WARN (ent->fts_path);
+              if (STREQ (program_name, "rm"))
+                {
+                  if (streq (ent->fts_path, "/"))
+                    error (0, 0,
+                           _("it is dangerous to operate recursively on %s"),
+                           quoteaf (ent->fts_path));
+                  else
+                    error (0, 0,
+                           _("it is dangerous to operate recursively on %s"
+                             " (same as %s)"),
+                           quoteaf_n (0, ent->fts_path),
+                           quoteaf_n (1, "/"));
+                  error (0, 0, _("use --allow-root-delete to override this "
+                                 "failsafe"));
+                }
+              else
+                ROOT_DEV_INO_WARN (ent->fts_path);
               fts_skip_tree (fts, ent);
               return RM_ERROR;
             }

--- a/src/remove.c
+++ b/src/remove.c
@@ -491,7 +491,7 @@ rm_fts (FTS *fts, FTSENT *ent, struct rm_options const *x)
                              " (same as %s)"),
                            quoteaf_n (0, ent->fts_path),
                            quoteaf_n (1, "/"));
-                  error (0, 0, _("use --allow-root-delete to override this "
+                  error (0, 0, _("use --agree-to-system-destruction to override this "
                                  "failsafe"));
                 }
               else

--- a/src/rm.c
+++ b/src/rm.c
@@ -321,10 +321,10 @@ main (int argc, char **argv)
           if (streq (argv[optind - 1], "--no-preserve-root"))
             error (0, 0, _("warning: option %s is deprecated; use %s"),
                    quoteaf_n (0, "--no-preserve-root"),
-            quoteaf_n (1, "--agree-to-system-destruction"));
+                   quoteaf_n (1, "--agree-to-system-destruction"));
           else if (! streq (argv[optind - 1], "--agree-to-system-destruction"))
             error (EXIT_FAILURE, 0,
-            _("you may not abbreviate the --agree-to-system-destruction option"));
+                   _("you may not abbreviate the --agree-to-system-destruction option"));
           preserve_root = false;
           break;
 

--- a/src/rm.c
+++ b/src/rm.c
@@ -64,7 +64,7 @@ static struct option const long_opts[] =
   {"interactive", optional_argument, NULL, INTERACTIVE_OPTION},
 
   {"one-file-system", no_argument, NULL, ONE_FILE_SYSTEM},
-  {"allow-root-delete", no_argument, NULL, NO_PRESERVE_ROOT},
+  {"agree-to-system-destruction", no_argument, NULL, NO_PRESERVE_ROOT},
   {"no-preserve-root", no_argument, NULL, NO_PRESERVE_ROOT},
   {"preserve-root", optional_argument, NULL, PRESERVE_ROOT},
 
@@ -160,7 +160,7 @@ Remove (unlink) the FILE(s).\n\
          from that of the corresponding command line argument\n\
 "));
       oputs (_("\
-      --allow-root-delete\n\
+      --agree-to-system-destruction\n\
          do not treat '/' specially\n\
 "));
       oputs (_("\
@@ -321,10 +321,10 @@ main (int argc, char **argv)
           if (streq (argv[optind - 1], "--no-preserve-root"))
             error (0, 0, _("warning: option %s is deprecated; use %s"),
                    quoteaf_n (0, "--no-preserve-root"),
-                   quoteaf_n (1, "--allow-root-delete"));
-          else if (! streq (argv[optind - 1], "--allow-root-delete"))
+            quoteaf_n (1, "--agree-to-system-destruction"));
+          else if (! streq (argv[optind - 1], "--agree-to-system-destruction"))
             error (EXIT_FAILURE, 0,
-                   _("you may not abbreviate the --allow-root-delete option"));
+            _("you may not abbreviate the --agree-to-system-destruction option"));
           preserve_root = false;
           break;
 

--- a/src/rm.c
+++ b/src/rm.c
@@ -64,6 +64,7 @@ static struct option const long_opts[] =
   {"interactive", optional_argument, NULL, INTERACTIVE_OPTION},
 
   {"one-file-system", no_argument, NULL, ONE_FILE_SYSTEM},
+  {"allow-root-delete", no_argument, NULL, NO_PRESERVE_ROOT},
   {"no-preserve-root", no_argument, NULL, NO_PRESERVE_ROOT},
   {"preserve-root", optional_argument, NULL, PRESERVE_ROOT},
 
@@ -159,7 +160,7 @@ Remove (unlink) the FILE(s).\n\
          from that of the corresponding command line argument\n\
 "));
       oputs (_("\
-      --no-preserve-root\n\
+      --allow-root-delete\n\
          do not treat '/' specially\n\
 "));
       oputs (_("\
@@ -317,9 +318,13 @@ main (int argc, char **argv)
           break;
 
         case NO_PRESERVE_ROOT:
-          if (! streq (argv[optind - 1], "--no-preserve-root"))
+          if (streq (argv[optind - 1], "--no-preserve-root"))
+            error (0, 0, _("warning: option %s is deprecated; use %s"),
+                   quoteaf_n (0, "--no-preserve-root"),
+                   quoteaf_n (1, "--allow-root-delete"));
+          else if (! streq (argv[optind - 1], "--allow-root-delete"))
             error (EXIT_FAILURE, 0,
-                   _("you may not abbreviate the --no-preserve-root option"));
+                   _("you may not abbreviate the --allow-root-delete option"));
           preserve_root = false;
           break;
 

--- a/tests/rm/r-root.sh
+++ b/tests/rm/r-root.sh
@@ -20,7 +20,7 @@
 print_ver_ rm
 
 # POSIX mandates rm(1) to skip '/' arguments.  This test verifies this mandated
-# behavior as well as the --preserve-root and --allow-root-delete options.
+# behavior as well as the --preserve-root and --agree-to-system-destruction options.
 # Especially the latter case is a live fire exercise as rm(1) is supposed to
 # enter the unlinkat() system call.  Therefore, limit the risk as much
 # as possible -- if there's a bug this test would wipe the system out!
@@ -123,7 +123,7 @@ clean_rm_err_()
 # which should be passed to 'rm'.
 # Paranoia mode on:
 # For the worst case where both rm(1) would fail to refuse to process the "/"
-# argument (in the cases without the --allow-root-delete option), and
+# argument (in the cases without the --agree-to-system-destruction option), and
 # intercepting the unlinkat(1) system call would fail (which actually already
 # has been proven to work above), and the current non root user has
 # write access to "/", limit the damage to the current file system via
@@ -188,11 +188,11 @@ for file in dir file ; do
          skip_ "internal test failure: maybe LD_PRELOAD or gdb doesn't work?"; }
 done
 
-# "rm -r /" without --allow-root-delete should output the following
+# "rm -r /" without --agree-to-system-destruction should output the following
 # diagnostic error message.
 cat <<EOD > exp || framework_failure_
 rm: it is dangerous to operate recursively on '/'
-rm: use --allow-root-delete to override this failsafe
+rm: use --agree-to-system-destruction to override this failsafe
 EOD
 
 #-------------------------------------------------------------------------------
@@ -228,11 +228,11 @@ for opts in           \
 done
 
 #-------------------------------------------------------------------------------
-# Exercise with --allow-root to ensure shortened equivalent is not allowed.
+# Exercise with --agree-to-system to ensure shortened equivalent is not allowed.
 cat <<EOD > exp_opt || framework_failure_
-rm: you may not abbreviate the --allow-root-delete option
+rm: you may not abbreviate the --agree-to-system-destruction option
 EOD
-returns_ 1 exercise_rm_r_root --allow-root / || fail=1
+returns_ 1 exercise_rm_r_root --agree-to-system / || fail=1
 compare exp_opt err || fail=1
 test -f x && fail=1
 
@@ -304,13 +304,13 @@ done
 
 #-------------------------------------------------------------------------------
 # Until now, it was all just fun.
-# Now exercise the --allow-root-delete option with which rm(1) should enter
+# Now exercise the --agree-to-system-destruction option with which rm(1) should enter
 # the intercepted unlinkat() system call.
 # As the interception code terminates the process immediately via _exit(0),
 # the exit status should be 0.
 # Use the option --interactive=never to bypass the following prompt:
 #   "rm: descend into write-protected directory '/'?"
-exercise_rm_r_root  --interactive=never --allow-root-delete '/' \
+exercise_rm_r_root  --interactive=never --agree-to-system-destruction '/' \
   || fail=1
 
 # The 'err' file should not contain the above error diagnostic.
@@ -323,7 +323,7 @@ test -f x || fail=1
 #-------------------------------------------------------------------------------
 # Verify --no-preserve-root remains accepted, but with a deprecation warning.
 exercise_rm_r_root --interactive=never --no-preserve-root '/' || fail=1
-grep "rm: warning: option '--no-preserve-root' is deprecated; use '--allow-root-delete'" err \
+grep "rm: warning: option '--no-preserve-root' is deprecated; use '--agree-to-system-destruction'" err \
   || fail=1
 test -f x || fail=1
 

--- a/tests/rm/r-root.sh
+++ b/tests/rm/r-root.sh
@@ -20,7 +20,7 @@
 print_ver_ rm
 
 # POSIX mandates rm(1) to skip '/' arguments.  This test verifies this mandated
-# behavior as well as the --preserve-root and --no-preserve-root options.
+# behavior as well as the --preserve-root and --allow-root-delete options.
 # Especially the latter case is a live fire exercise as rm(1) is supposed to
 # enter the unlinkat() system call.  Therefore, limit the risk as much
 # as possible -- if there's a bug this test would wipe the system out!
@@ -123,7 +123,7 @@ clean_rm_err_()
 # which should be passed to 'rm'.
 # Paranoia mode on:
 # For the worst case where both rm(1) would fail to refuse to process the "/"
-# argument (in the cases without the --no-preserve-root option), and
+# argument (in the cases without the --allow-root-delete option), and
 # intercepting the unlinkat(1) system call would fail (which actually already
 # has been proven to work above), and the current non root user has
 # write access to "/", limit the damage to the current file system via
@@ -188,11 +188,11 @@ for file in dir file ; do
          skip_ "internal test failure: maybe LD_PRELOAD or gdb doesn't work?"; }
 done
 
-# "rm -r /" without --no-preserve-root should output the following
+# "rm -r /" without --allow-root-delete should output the following
 # diagnostic error message.
 cat <<EOD > exp || framework_failure_
 rm: it is dangerous to operate recursively on '/'
-rm: use --no-preserve-root to override this failsafe
+rm: use --allow-root-delete to override this failsafe
 EOD
 
 #-------------------------------------------------------------------------------
@@ -228,11 +228,11 @@ for opts in           \
 done
 
 #-------------------------------------------------------------------------------
-# Exercise with --no-preserve to ensure shortened equivalent is not allowed.
+# Exercise with --allow-root to ensure shortened equivalent is not allowed.
 cat <<EOD > exp_opt || framework_failure_
-rm: you may not abbreviate the --no-preserve-root option
+rm: you may not abbreviate the --allow-root-delete option
 EOD
-returns_ 1 exercise_rm_r_root --no-preserve / || fail=1
+returns_ 1 exercise_rm_r_root --allow-root / || fail=1
 compare exp_opt err || fail=1
 test -f x && fail=1
 
@@ -304,13 +304,13 @@ done
 
 #-------------------------------------------------------------------------------
 # Until now, it was all just fun.
-# Now exercise the --no-preserve-root option with which rm(1) should enter
+# Now exercise the --allow-root-delete option with which rm(1) should enter
 # the intercepted unlinkat() system call.
 # As the interception code terminates the process immediately via _exit(0),
 # the exit status should be 0.
 # Use the option --interactive=never to bypass the following prompt:
 #   "rm: descend into write-protected directory '/'?"
-exercise_rm_r_root  --interactive=never --no-preserve-root '/' \
+exercise_rm_r_root  --interactive=never --allow-root-delete '/' \
   || fail=1
 
 # The 'err' file should not contain the above error diagnostic.
@@ -318,6 +318,13 @@ grep "rm: it is dangerous to operate recursively on '/'" err && fail=1
 
 # Instead, rm(1) should have called the intercepted unlinkat() function,
 # i.e., the evidence file "x" should exist.
+test -f x || fail=1
+
+#-------------------------------------------------------------------------------
+# Verify --no-preserve-root remains accepted, but with a deprecation warning.
+exercise_rm_r_root --interactive=never --no-preserve-root '/' || fail=1
+grep "rm: warning: option '--no-preserve-root' is deprecated; use '--allow-root-delete'" err \
+  || fail=1
 test -f x || fail=1
 
 test $fail = 1 && { cat out; cat err; }


### PR DESCRIPTION
This pull request updates the `rm` command to replace the `--no-preserve-root` option with a new, more explicit `--agree-to-system-destruction` option for removing the root directory `/`. The changes improve safety messaging and deprecate the old option, while updating documentation and tests to match the new behavior.

**Command-line interface and behavior changes:**

* Added a new `--agree-to-system-destruction` option to allow recursive removal of `/`, replacing the previous `--no-preserve-root` option.
* When `--no-preserve-root` is used, a deprecation warning is displayed, advising users to use `--agree-to-system-destruction` instead. Abbreviations for the new option are not allowed.
* Updated warning and error messages to reference `--agree-to-system-destruction` instead of `--no-preserve-root`, and clarified the dangers of recursive operations on `/`. [[1]](diffhunk://#diff-d95587391a2b1e32f465cf4c90feba418a5ed88d159ce7e9f233bd7c15b6d6cdR482-R497) [[2]](diffhunk://#diff-98853e9c9f7d74f24385338d0dfe36d1c3c759ba39760c4842fe0f002c71c4baL162-R163)

**Test and documentation updates:**

* Updated test scripts in `tests/rm/r-root.sh` to use and check for `--agree-to-system-destruction` and to verify the deprecation warning for `--no-preserve-root`. 