### PR TITLE
tests: dd: replace LD_PRELOAD of fail-ftruncate-fstat.sh by strace

### DIFF
--- a/tests/dd/fail-ftruncate-fstat.sh
+++ b/tests/dd/fail-ftruncate-fstat.sh
@@ -18,52 +18,22 @@
 
 . "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
 print_ver_ dd
-require_gcc_shared_
+uses_strace_
 getlimits_
-
-cat > k.c <<'EOF' || framework_failure_
-#include <sys/stat.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <errno.h>
-
-int
-ftruncate (int fd, off_t length)
-{
-  /* Prove that LD_PRELOAD works: create the evidence file "x".  */
-  fclose (fopen ("x", "w"));
-
-  /* Pretend failure.  */
-  errno = EPERM;
-  return -1;
-}
-
-int
-fstat (int fd, struct stat *statbuf)
-{
-  /* Prove that LD_PRELOAD works: create the evidence file "y".  */
-  fclose (fopen ("y", "w"));
-
-  /* Pretend failure.  */
-  errno = EPERM;
-  return -1;
-}
-EOF
-
-# Then compile/link it:
-gcc_shared_ k.c k.so \
-  || framework_failure_ 'failed to build shared library'
 
 # Setup the file "out" and preserve it's original contents in "exp-out".
 yes | head -n 2048 | tr -d '\n' > out || framework_failure_
 cp out exp-out || framework_failure_
 
-LD_PRELOAD=$LD_PRELOAD:./k.so dd if=/dev/zero of=out count=1 \
-                              seek=1 status=none 2>err
+strace -o strace.out \
+  -e fault=ftruncate:error=EPERM \
+  -e fault=fstat:error=EPERM \
+  -P out \
+  dd if=/dev/zero of=out count=1 seek=1 status=none 2>err
+
 ret=$?
 
-test -f x && test -f y \
-  || skip_ "internal test failure: maybe LD_PRELOAD doesn't work?"
+grep -oE '^(fstat|ftruncate)' strace.out || skip_ "ftruncate or fstat are not used"
 
 # After ftruncate fails, we use fstat to get the file type.
 echo "dd: cannot fstat 'out': $EPERM" > exp


### PR DESCRIPTION
* tests/dd/fail-ftruncate-fstat.sh: Replace LD_PRELOAD by strace to support static executables.