### PR TITLE
tests: stat: check nanosecond precision away from the Epoch

### DIFF
--- a/tests/stat/stat-nanoseconds.sh
+++ b/tests/stat/stat-nanoseconds.sh
@@ -43,4 +43,21 @@ test "$(stat -c %I18.10Y k)" = '  67413.0234567890'   || fail=1
 test "$(stat -c %018.10Y k)" =  0067413.0234567890    || fail=1
 test "$(stat -c %-18.10Y k)" =   '67413.0234567890  ' || fail=1
 
+# A recent timestamp needs more than the 53 bits of a double to hold
+# all nine fractional digits.
+touch -d '2026-05-04 03:02:01.987654321' recent || framework_failure_
+
+test "$(stat -c   %Y recent)" = 1777863721            || fail=1
+test "$(stat -c  %.Y recent)" = 1777863721.987654321  || fail=1
+test "$(stat -c %.3Y recent)" = 1777863721.987        || fail=1
+test "$(stat -c %.9Y recent)" = 1777863721.987654321  || fail=1
+
+# Timestamps before the Epoch truncate towards minus infinity.
+touch -d '1969-12-31 23:59:59.123456789' old || framework_failure_
+
+test "$(stat -c   %Y old)" = -1            || fail=1
+test "$(stat -c  %.Y old)" = -0.876543211  || fail=1
+test "$(stat -c %.3Y old)" = -0.876        || fail=1
+test "$(stat -c %.9Y old)" = -0.876543211  || fail=1
+
 Exit $fail


### PR DESCRIPTION
The existing checks all use a timestamp only 67413 seconds after the Epoch, which a double can still represent exactly to the nanosecond, so they do not detect a formatter that goes through floating point.  They also never look at a timestamp before the Epoch, where the fraction has to be truncated towards minus infinity.

* tests/stat/stat-nanoseconds.sh: Also check %Y, %.Y, %.3Y and %.9Y on a 2026 timestamp and on a timestamp shortly before the Epoch.
  https://github.com/uutils/coreutils/pull/13976
