### PR TITLE
tests: expand, unexpand: check blank-separated tab lists

### DIFF
--- a/tests/expand/expand.pl
+++ b/tests/expand/expand.pl
@@ -35,6 +35,8 @@ my @Tests =
    # Leading space/commas are silently ignored; Mixing space/commas is allowed.
    # (a side-effect of allowing direct "-3,9" parameter).
    ['t4', '--tabs=", 3,6 9"', {IN=>"a\tb\tc\td\te"}, {OUT=>"a  b  c  d e"}],
+   # Any blank separates, not just a space.
+   ['t4a', "--tabs=\"3\t6\t9\"", {IN=>"a\tb\tc\td\te"}, {OUT=>"a  b  c  d e"}],
    # tab stops parameter without values
    ['t5', '--tabs=""',        {IN=>"a\tb\tc"}, {OUT=>"a       b       c"}],
    ['t6', '--tabs=","',       {IN=>"a\tb\tc"}, {OUT=>"a       b       c"}],

--- a/tests/unexpand/unexpand.pl
+++ b/tests/unexpand/unexpand.pl
@@ -60,6 +60,12 @@ my @Tests =
      # Feature addition (--first-only) prompted by a report from Jie Xu.
      ['tabs-1', qw(-t 3),              {IN=> "   a  b\n"}, {OUT=>"\ta\tb\n"}],
      ['tabs-2', qw(-t 3 --first-only), {IN=> "   a  b\n"}, {OUT=>"\ta  b\n"}],
+     # A tab list is separated by commas or by blanks, and leading
+     # separators are ignored.
+     ['tabs-3', '-t "3,6"',       {IN=> "   a  b\n"}, {OUT=>"\ta\tb\n"}],
+     ['tabs-4', '-t "3 6"',       {IN=> "   a  b\n"}, {OUT=>"\ta\tb\n"}],
+     ['tabs-5', "-t \"3\t6\"",    {IN=> "   a  b\n"}, {OUT=>"\ta\tb\n"}],
+     ['tabs-6', '-t ", 3,6"',     {IN=> "   a  b\n"}, {OUT=>"\ta\tb\n"}],
 
      # blanks
      ['blanks-1', qw(-t 1), {IN=> " b  c   d\n"}, {OUT=> "\tb\t\tc\t\t\td\n"}],


### PR DESCRIPTION
parse_tab_stops accepts a comma or any blank as a separator, but the tests only ever used a comma or a space, so a tab separator was untested.  unexpand had no coverage of multi-stop lists at all. Missing case identified here:
https://github.com/uutils/coreutils/pull/14057

* tests/expand/expand.pl (t4a): New test, using tabs as separators.
* tests/unexpand/unexpand.pl (tabs-3, tabs-4, tabs-5, tabs-6): New tests, for comma-, space- and tab-separated lists and for a leading separator.
