### PR TITLE
tests: env: support referencing of external env

### DIFF
--- a/tests/env/env-S-script.sh
+++ b/tests/env/env-S-script.sh
@@ -23,6 +23,7 @@ print_ver_ printf
 
 require_perl_
 
+env=$(command -v env)
 # a shortcut to avoid long lines
 dir="$abs_top_builddir/src"
 
@@ -42,7 +43,7 @@ EOF
 chmod a+x shebang || framework_failure_
 
 # A simple shebang program to call our new "env"
-printf "#!$dir/env sh\necho hello\n" > env_test || framework_failure_
+printf "#!${env} sh\necho hello\n" > env_test || framework_failure_
 chmod a+x env_test || framework_failure_
 
 # Verify we can run the shebang which is not the case if
@@ -54,7 +55,7 @@ chmod a+x env_test || framework_failure_
 # the name of the executed script, and its 3 parameters (C,D,'E F').
 # Ignoring the absolute paths, the script is:
 #     #!env -S printf x%sx\n A B
-printf "#!$dir/env -S $dir/printf "'x%%sx\\n A B\n' > env1 || framework_failure_
+printf "#!${env} -S $dir/printf "'x%%sx\\n A B\n' > env1 || framework_failure_
 chmod a+x env1 || framework_failure_
 cat<<\EOF>exp1 || framework_failure_
 xAx
@@ -72,7 +73,7 @@ compare exp1 out1 || fail=1
 # 'A B' and not two parameters 'A','B'.
 # Ignoring the absolute paths, the script is:
 #     #!env -S printf x%sx\n "A B"
-printf "#!$dir/env -S $dir/printf "'x%%sx\\n "A B"\n' > env2 ||
+printf "#!${env} -S $dir/printf "'x%%sx\\n "A B"\n' > env2 ||
   framework_failure_
 chmod a+x env2 || framework_failure_
 cat<<\EOF>exp2 || framework_failure_
@@ -86,7 +87,7 @@ compare exp2 out2 || fail=1
 # backslash-underscore instead of spaces.
 # Ignoring the absolute paths, the script is:
 #     #!env -Sprintf\_x%sx\n\_Y
-printf "#!$dir/env -S$dir/printf"'\\_x%%sx\\n\\_Y\n' > env3 ||
+printf "#!${env} -S$dir/printf"'\\_x%%sx\\n\\_Y\n' > env3 ||
   framework_failure_
 chmod a+x env3 || framework_failure_
 cat<<\EOF>exp3 || framework_failure_
@@ -102,7 +103,7 @@ compare exp3 out3 || fail=1
 # Test comments - The "#C D" should be ignored.
 # Ignoring the absolute paths, the script is:
 #     #!env -Sprintf x%sx\n A#B #C D
-printf "#!$dir/env -S$dir/printf"' x%%sx\\n A#B #C D\n' > env4 \
+printf "#!${env} -S$dir/printf"' x%%sx\\n A#B #C D\n' > env4 \
     || framework_failure_
 chmod a+x env4 || framework_failure_
 cat<<\EOF>exp4 || framework_failure_
@@ -119,7 +120,7 @@ compare exp4 out4 || fail=1
 # Ignoring the absolute paths, the script is:
 #     #!env -S perl -w -T
 #     print "hello\n";
-{ printf "#!$dir/env -S $PERL -w -T\n" ;
+{ printf "#!${env} -S $PERL -w -T\n" ;
   printf 'print "hello\\n";\n' ; } > env5 || framework_failure_
 chmod a+x env5 || framework_failure_
 cat<<\EOF>exp5 || framework_failure_
@@ -134,7 +135,7 @@ compare exp5 out5 || fail=1
 #     #!env -S perl -mFile::Basename=basename -e "print basename(\$ARGV[0]);"
 # The backslash before the '$' is required to prevent env(1) from treating
 # $ARGV as an (invalid syntax) envvar, and pass it as-is to Perl.
-{ printf "#!$dir/env -S " ;
+{ printf "#!${env} -S " ;
   printf "$PERL -mFile::Basename=basename -e " ;
   printf '"print basename(\\$ARGV[0]);"\n' ; } > env6 || framework_failure_
 chmod a+x env6 || framework_failure_


### PR DESCRIPTION
* tests/env/env-S-script.sh‎: Use command -v env instead of $abs_top_builddir for external usage of tests.

separated from https://github.com/coreutils/coreutils/pull/175
`env printf` is not used at here (it is probably not important for uutils...).