### PR TITLE
tests: mv: check cross-device move of dir with hard links and symlink

### DIFF
--- a/tests/local.mk
+++ b/tests/local.mk
@@ -805,6 +805,7 @@ all_tests =					\
   tests/mv/no-target-dir.sh			\
   tests/mv/part-fail.sh				\
   tests/mv/part-hardlink.sh			\
+  tests/mv/part-hardlink-symlink.sh		\
   tests/mv/part-rename.sh			\
   tests/mv/part-symlink.sh			\
   tests/mv/partition-perm.sh			\

--- a/tests/mv/part-hardlink-symlink.sh
+++ b/tests/mv/part-hardlink-symlink.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Ensure that moving a directory across file systems preserves both
+# hard links and symlinks contained in it.
+
+# Copyright (C) 2026 Free Software Foundation, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
+print_ver_ mv
+cleanup_() { rm -rf "$other_partition_tmpdir"; }
+. "$abs_srcdir/tests/other-fs-tmpdir"
+
+# A directory holding a hard linked pair of files, and a symlink to one
+# of them.  The link count > 1 combined with the symlink used to be
+# enough to confuse some implementations into replacing the regular
+# files with symlinks, thus losing the data.
+mkdir d || framework_failure_
+printf 'important data' > d/realfile || framework_failure_
+ln d/realfile d/realfile2 || framework_failure_
+ln -s realfile d/link1 || framework_failure_
+
+printf 'important data' > exp || framework_failure_
+
+mv d "$other_partition_tmpdir" || fail=1
+
+# The source directory must be gone.
+test -d d && fail=1
+
+dest="$other_partition_tmpdir/d"
+
+# The regular files must still be regular files with the original data.
+for f in realfile realfile2; do
+  test -f "$dest/$f" || fail=1
+  test -L "$dest/$f" && fail=1
+  compare exp "$dest/$f" || fail=1
+done
+
+# ... and must still be hard linked together.
+set -- $(ls -Ci "$dest/realfile" "$dest/realfile2")
+test $1 = $3 || fail=1
+
+# The symlink must still be a symlink to realfile.
+test -L "$dest/link1" || fail=1
+test "$(readlink "$dest/link1")" = realfile || fail=1
+
+Exit $fail


### PR DESCRIPTION
* tests/mv/part-hardlink-symlink.sh: New test, ensuring that moving a directory to another file system preserves the contents and the hard links of its regular files, as well as the symlinks pointing at them.
* tests/local.mk (all_tests): Add it. https://github.com/uutils/coreutils/pull/14170
