### PR TITLE
tests: support referencing of external commands

### DIFF
--- a/tests/misc/close-stdout.sh
+++ b/tests/misc/close-stdout.sh
@@ -20,9 +20,6 @@
 . "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
 print_ver_ rm
 
-p=$abs_top_builddir
-
-
 # Ensure these exit successfully, even though stdout is closed,
 # because they generate no output.
 touch a
@@ -36,15 +33,15 @@ mv d e >&- || fail=1
 rmdir e >&- || fail=1
 touch e >&- || fail=1
 sleep 0 >&- || fail=1
-"$p/src/true" >&- || fail=1
-"$p/src/printf" '' >&- || fail=1
+env true >&- || fail=1
+env printf '' >&- || fail=1
 
 # If >&- works, ensure these fail, because stdout is closed and they
 # *do* generate output.  >&- apparently does not work in HP-UX 11.23.
 # This test is ineffective unless /dev/stdout also works.
-if "$p/src/test" -w /dev/stdout >/dev/null &&
-   "$p/src/test" ! -w /dev/stdout >&-; then
-  returns_ 1 "$p/src/printf" 'foo' >&- 2>/dev/null || fail=1
+if env test -w /dev/stdout >/dev/null &&
+   env test ! -w /dev/stdout >&-; then
+  returns_ 1 env printf 'foo' >&- 2>/dev/null || fail=1
   returns_ 1 cp --verbose a b >&- 2>/dev/null || fail=1
   rm -Rf tmpfile-?????? || fail=1
   returns_ 1 mktemp tmpfile-XXXXXX >&- 2>/dev/null || fail=1
@@ -54,7 +51,7 @@ fi
 
 # Likewise for /dev/full, if /dev/full works.
 if test -w /dev/full && test -c /dev/full; then
-  returns_ 1 "$p/src/printf" 'foo' >/dev/full 2>/dev/null || fail=1
+  returns_ 1 env printf 'foo' >/dev/full 2>/dev/null || fail=1
   returns_ 1 cp --verbose a b >/dev/full 2>/dev/null || fail=1
   rm -Rf tmpdir-?????? || fail=1
   returns_ 1 mktemp -d tmpdir-XXXXXX >/dev/full 2>/dev/null || fail=1


### PR DESCRIPTION
* tests/misc/close-stdout.sh: Use `cmd_exe` instead of $abs_top_builddir for external usage of tests.

~I don't know why we cannot use `builtin test` at here.~