### PR TITLE
Touch mode option

### DIFF
--- a/doc/coreutils.texi
+++ b/doc/coreutils.texi
@@ -11753,6 +11753,19 @@ Change the access timestamp only.  @xref{File timestamps}.
 @optItemx{touch,--no-create,}
 Do not warn about or create files that do not exist.
 
+@optItem{touch,--mode,=@var{mode}}
+@opindex mode
+Use @var{mode} as the permissions for files newly created by @command{touch}.
+The mode is interpreted as an octal file mode and is subject to the
+process's file creation mask (@code{umask}).
+
+This option does not change the permissions of files that already exist.
+For example:
+
+@example
+touch --mode=0755 script
+@end example
+
 @optItem{touch,-d,@w{ }@var{time}}
 @optItemx{touch,--date,=@var{time}}
 @opindex time

--- a/src/touch.c
+++ b/src/touch.c
@@ -36,12 +36,12 @@
 /* The official name of this program (e.g., no 'g' prefix).  */
 #define PROGRAM_NAME "touch"
 
-#define AUTHORS \
-  proper_name ("Paul Rubin"), \
-  proper_name ("Arnold Robbins"), \
-  proper_name ("Jim Kingdon"), \
-  proper_name ("David MacKenzie"), \
-  proper_name ("Randy Smith")
+#define AUTHORS                       \
+  proper_name("Paul Rubin"),          \
+      proper_name("Arnold Robbins"),  \
+      proper_name("Jim Kingdon"),     \
+      proper_name("David MacKenzie"), \
+      proper_name("Randy Smith")
 
 /* Bitmasks for 'change_times'. */
 #define CH_ATIME 1
@@ -58,6 +58,10 @@ static bool use_ref;
 
 /* (-h) If true, change the times of an existing symlink, if possible.  */
 static bool no_dereference;
+
+/* Permission mode to use when creating new files.
+   Subject to the process umask.  */
+static mode_t create_mode = MODE_RW_UGO;
 
 /* If true, the only thing we have to do is change both the
    modification and access time to the current time, so we don't
@@ -76,145 +80,162 @@ static char *ref_file;
    non-character as a pseudo short option, starting with CHAR_MAX + 1.  */
 enum
 {
-  TIME_OPTION = CHAR_MAX + 1
+  TIME_OPTION = CHAR_MAX + 1,
+  MODE_OPTION
 };
 
 static struct option const longopts[] =
-{
-  {"time", required_argument, NULL, TIME_OPTION},
-  {"no-create", no_argument, NULL, 'c'},
-  {"date", required_argument, NULL, 'd'},
-  {"reference", required_argument, NULL, 'r'},
-  {"no-dereference", no_argument, NULL, 'h'},
-  {GETOPT_HELP_OPTION_DECL},
-  {GETOPT_VERSION_OPTION_DECL},
-  {NULL, 0, NULL, 0}
-};
+    {
+        {"time", required_argument, NULL, TIME_OPTION},
+        {"mode", required_argument, NULL, MODE_OPTION},
+        {"no-create", no_argument, NULL, 'c'},
+        {"date", required_argument, NULL, 'd'},
+        {"reference", required_argument, NULL, 'r'},
+        {"no-dereference", no_argument, NULL, 'h'},
+        {GETOPT_HELP_OPTION_DECL},
+        {GETOPT_VERSION_OPTION_DECL},
+        {NULL, 0, NULL, 0}};
 
 /* Valid arguments to the '--time' option. */
 static char const *const time_args[] =
-{
-  "atime", "access", "use", "mtime", "modify", NULL
-};
+    {
+        "atime", "access", "use", "mtime", "modify", NULL};
 
 /* The bits in 'change_times' that those arguments set. */
 static int const time_masks[] =
-{
-  CH_ATIME, CH_ATIME, CH_ATIME, CH_MTIME, CH_MTIME
-};
+    {
+        CH_ATIME, CH_ATIME, CH_ATIME, CH_MTIME, CH_MTIME};
 
 /* The interpretation of FLEX_DATE as a date, relative to NOW.  */
 
 static struct timespec
-date_relative (char const *flex_date, struct timespec now)
+date_relative(char const *flex_date, struct timespec now)
 {
   struct timespec result;
-  if (! parse_datetime (&result, flex_date, &now))
-    error (EXIT_FAILURE, 0, _("invalid date format %s"), quote (flex_date));
+  if (!parse_datetime(&result, flex_date, &now))
+    error(EXIT_FAILURE, 0, _("invalid date format %s"), quote(flex_date));
   return result;
+}
+
+static mode_t
+parse_mode(char const *mode_string)
+{
+  char *end;
+
+  if (*mode_string == '\0' || *mode_string == '-')
+    error(EXIT_FAILURE, 0,
+          _("invalid mode %s"), quote(mode_string));
+
+  errno = 0;
+
+  unsigned long mode = strtoul(mode_string, &end, 8);
+
+  if (errno != 0 || *end != '\0' || mode > 07777)
+    error(EXIT_FAILURE, 0,
+          _("invalid mode %s"), quote(mode_string));
+
+  return (mode_t)mode;
 }
 
 /* Update the time of file FILE according to the options given.
    Return true if successful.  */
 
 static bool
-touch (char const *file)
+touch(char const *file)
 {
   int fd = -1;
   int open_errno = 0;
   struct timespec const *t = newtime;
 
-  if (streq (file, "-"))
+  if (streq(file, "-"))
     fd = STDOUT_FILENO;
-  else if (! (no_create || no_dereference))
-    {
-      /* Try to open FILE, creating it if necessary.  */
-      fd = fd_reopen (STDIN_FILENO, file,
-                      O_WRONLY | O_CREAT | O_NONBLOCK | O_NOCTTY, MODE_RW_UGO);
-      if (fd < 0)
-        open_errno = errno;
-    }
+  else if (!(no_create || no_dereference))
+  {
+    /* Try to open FILE, creating it if necessary.  */
+    fd = fd_reopen(STDIN_FILENO, file,
+                   O_WRONLY | O_CREAT | O_NONBLOCK | O_NOCTTY,
+                   create_mode);
+    if (fd < 0)
+      open_errno = errno;
+  }
 
   if (change_times != (CH_ATIME | CH_MTIME))
+  {
+    /* We're setting only one of the time values.  */
+    if (change_times == CH_MTIME)
+      newtime[0].tv_nsec = UTIME_OMIT;
+    else
     {
-      /* We're setting only one of the time values.  */
-      if (change_times == CH_MTIME)
-        newtime[0].tv_nsec = UTIME_OMIT;
-      else
-        {
-          affirm (change_times == CH_ATIME);
-          newtime[1].tv_nsec = UTIME_OMIT;
-        }
+      affirm(change_times == CH_ATIME);
+      newtime[1].tv_nsec = UTIME_OMIT;
     }
+  }
 
   if (amtime_now)
-    {
-      /* Pass NULL to futimens so it will not fail if we have
-         write access to the file, but don't own it.  */
-      t = NULL;
-    }
+  {
+    /* Pass NULL to futimens so it will not fail if we have
+       write access to the file, but don't own it.  */
+    t = NULL;
+  }
 
   char const *file_opt = fd == STDOUT_FILENO ? NULL : file;
   int atflag = no_dereference ? AT_SYMLINK_NOFOLLOW : 0;
-  int utime_errno = (fdutimensat (fd, AT_FDCWD, file_opt, t, atflag) == 0
-                     ? 0 : errno);
+  int utime_errno = (fdutimensat(fd, AT_FDCWD, file_opt, t, atflag) == 0
+                         ? 0
+                         : errno);
 
   if (fd == STDIN_FILENO)
+  {
+    if (close(STDIN_FILENO) != 0)
     {
-      if (close (STDIN_FILENO) != 0)
-        {
-          error (0, errno, _("failed to close %s"), quoteaf (file));
-          return false;
-        }
-    }
-  else if (fd == STDOUT_FILENO)
-    {
-      /* Do not diagnose "touch -c - >&-".  */
-      if (utime_errno == EBADF && no_create)
-        return true;
-    }
-
-  if (utime_errno != 0)
-    {
-      /* Don't diagnose with open_errno if FILE is a directory, as that
-         would give a bogus diagnostic for e.g., 'touch /' (assuming we
-         don't own / or have write access).  On Solaris 10 and probably
-         other systems, opening a directory like "." fails with EINVAL.
-         (On SunOS 4 it was EPERM but that's obsolete.)  On macOS 26
-         opening "/" fails with EEXIST.  */
-      struct stat st;
-      if (open_errno
-          && ! (open_errno == EISDIR
-                || ((open_errno == EINVAL || open_errno == EEXIST)
-                    && stat (file, &st) == 0 && S_ISDIR (st.st_mode))))
-        {
-          /* The wording of this diagnostic should cover at least two cases:
-             - the file does not exist, but the parent directory is unwritable
-             - the file exists, but it isn't writable
-             I think it's not worth trying to distinguish them.  */
-          error (0, open_errno, _("cannot touch %s"), quoteaf (file));
-        }
-      else
-        {
-          if (no_create && utime_errno == ENOENT)
-            return true;
-          error (0, utime_errno, _("setting times of %s"), quoteaf (file));
-        }
+      error(0, errno, _("failed to close %s"), quoteaf(file));
       return false;
     }
+  }
+  else if (fd == STDOUT_FILENO)
+  {
+    /* Do not diagnose "touch -c - >&-".  */
+    if (utime_errno == EBADF && no_create)
+      return true;
+  }
+
+  if (utime_errno != 0)
+  {
+    /* Don't diagnose with open_errno if FILE is a directory, as that
+       would give a bogus diagnostic for e.g., 'touch /' (assuming we
+       don't own / or have write access).  On Solaris 10 and probably
+       other systems, opening a directory like "." fails with EINVAL.
+       (On SunOS 4 it was EPERM but that's obsolete.)  On macOS 26
+       opening "/" fails with EEXIST.  */
+    struct stat st;
+    if (open_errno && !(open_errno == EISDIR || ((open_errno == EINVAL || open_errno == EEXIST) && stat(file, &st) == 0 && S_ISDIR(st.st_mode))))
+    {
+      /* The wording of this diagnostic should cover at least two cases:
+         - the file does not exist, but the parent directory is unwritable
+         - the file exists, but it isn't writable
+         I think it's not worth trying to distinguish them.  */
+      error(0, open_errno, _("cannot touch %s"), quoteaf(file));
+    }
+    else
+    {
+      if (no_create && utime_errno == ENOENT)
+        return true;
+      error(0, utime_errno, _("setting times of %s"), quoteaf(file));
+    }
+    return false;
+  }
 
   return true;
 }
 
-void
-usage (int status)
+void usage(int status)
 {
   if (status != EXIT_SUCCESS)
-    emit_try_help ();
+    emit_try_help();
   else
-    {
-      printf (_("Usage: %s [OPTION]... FILE...\n"), program_name);
-      fputs (_("\
+  {
+    printf(_("Usage: %s [OPTION]... FILE...\n"), program_name);
+    fputs(_("\
 Update the access and modification times of each FILE to the current time.\n\
 \n\
 A FILE argument that does not exist is created empty, unless -c or -h\n\
@@ -222,230 +243,235 @@ is supplied.\n\
 \n\
 A FILE argument string of - is handled specially and causes touch to\n\
 change the times of the file associated with standard output.\n\
-"), stdout);
+"),
+          stdout);
 
-      emit_mandatory_arg_note ();
+    emit_mandatory_arg_note();
 
-      oputs (_("\
+    oputs(_("\
   -a\n\
          change only the access time\n\
 "));
-      oputs (_("\
+    oputs(_("\
   -c, --no-create\n\
          do not create any files\n\
 "));
-      oputs (_("\
+    oputs(_("\
   -d, --date=STRING\n\
          parse STRING and use it instead of current time\n\
 "));
-      oputs (_("\
+    oputs(_("\
   -f\n\
          (ignored)\n\
 "));
-      oputs (_("\
+    oputs(_("\
   -h, --no-dereference\n\
          affect each symbolic link instead of any referenced file;\n\
          useful only on systems that can change the timestamps of a symlink\n\
 "));
-      oputs (_("\
+    oputs(_("\
   -m\n\
          change only the modification time\n\
 "));
-      oputs (_("\
+    oputs(_("\
   -r, --reference=FILE\n\
          use this file's times instead of current time\n\
 "));
-      oputs (_("\
+    oputs(_("\
   -t [[CC]YY]MMDDhhmm[.ss]\n\
          use specified time instead of current time,\n\
          with a date-time format that differs from -d's\n\
 "));
-      oputs (_("\
+    oputs(_("\
+      --mode=MODE\n\
+         use MODE as the permissions for newly created files;\n\
+         MODE is interpreted as an octal number and is subject to umask\n\
+"));
+    oputs(_("\
       --time=WORD\n\
          specify which time to change:\n\
          access time (-a): 'access', 'atime', 'use';\n\
          modification time (-m): 'modify', 'mtime'\n\
 "));
-      oputs (HELP_OPTION_DESCRIPTION);
-      oputs (VERSION_OPTION_DESCRIPTION);
-      emit_ancillary_info (PROGRAM_NAME);
-    }
-  exit (status);
+    oputs(HELP_OPTION_DESCRIPTION);
+    oputs(VERSION_OPTION_DESCRIPTION);
+    emit_ancillary_info(PROGRAM_NAME);
+  }
+  exit(status);
 }
 
-int
-main (int argc, char **argv)
+int main(int argc, char **argv)
 {
   bool date_set = false;
   char const *flex_date = NULL;
 
-  initialize_main (&argc, &argv);
-  set_program_name (argv[0]);
-  setlocale (LC_ALL, "");
-  bindtextdomain (PACKAGE, LOCALEDIR);
-  textdomain (PACKAGE);
+  initialize_main(&argc, &argv);
+  set_program_name(argv[0]);
+  setlocale(LC_ALL, "");
+  bindtextdomain(PACKAGE, LOCALEDIR);
+  textdomain(PACKAGE);
 
-  atexit (close_stdout);
+  atexit(close_stdout);
 
   int c;
-  while ((c = getopt_long (argc, argv, "acd:fhmr:t:", longopts, NULL)) != -1)
+  while ((c = getopt_long(argc, argv, "acd:fhmr:t:", longopts, NULL)) != -1)
+  {
+    switch (c)
     {
-      switch (c)
-        {
-        case 'a':
-          change_times |= CH_ATIME;
-          break;
+    case 'a':
+      change_times |= CH_ATIME;
+      break;
 
-        case 'c':
-          no_create = true;
-          break;
+    case 'c':
+      no_create = true;
+      break;
 
-        case 'd':
-          flex_date = optarg;
-          break;
+    case 'd':
+      flex_date = optarg;
+      break;
 
-        case 'f':
-          break;
+    case 'f':
+      break;
 
-        case 'h':
-          no_dereference = true;
-          break;
+    case 'h':
+      no_dereference = true;
+      break;
 
-        case 'm':
-          change_times |= CH_MTIME;
-          break;
+    case 'm':
+      change_times |= CH_MTIME;
+      break;
 
-        case 'r':
-          use_ref = true;
-          ref_file = optarg;
-          break;
+    case 'r':
+      use_ref = true;
+      ref_file = optarg;
+      break;
 
-        case 't':
-          if (! posixtime (&newtime[0].tv_sec, optarg,
-                           PDS_LEADING_YEAR | PDS_CENTURY | PDS_SECONDS))
-            error (EXIT_FAILURE, 0, _("invalid date format %s"),
-                   quote (optarg));
-          newtime[0].tv_nsec = 0;
-          newtime[1] = newtime[0];
-          date_set = true;
-          break;
+    case 't':
+      if (!posixtime(&newtime[0].tv_sec, optarg,
+                     PDS_LEADING_YEAR | PDS_CENTURY | PDS_SECONDS))
+        error(EXIT_FAILURE, 0, _("invalid date format %s"),
+              quote(optarg));
+      newtime[0].tv_nsec = 0;
+      newtime[1] = newtime[0];
+      date_set = true;
+      break;
 
-        case TIME_OPTION:	/* --time */
-          change_times |= XARGMATCH ("--time", optarg,
-                                     time_args, time_masks);
-          break;
+    case TIME_OPTION: /* --time */
+      change_times |= XARGMATCH("--time", optarg,
+                                time_args, time_masks);
+      break;
+    case MODE_OPTION: /* --mode */
+      create_mode = parse_mode(optarg);
+      break;
 
-        case_GETOPT_HELP_CHAR;
+      case_GETOPT_HELP_CHAR;
 
-        case_GETOPT_VERSION_CHAR (PROGRAM_NAME, AUTHORS);
+      case_GETOPT_VERSION_CHAR(PROGRAM_NAME, AUTHORS);
 
-        default:
-          usage (EXIT_FAILURE);
-        }
+    default:
+      usage(EXIT_FAILURE);
     }
+  }
 
   if (change_times == 0)
     change_times = CH_ATIME | CH_MTIME;
 
   if (date_set && (use_ref || flex_date))
-    {
-      error (0, 0, _("cannot specify times from more than one source"));
-      usage (EXIT_FAILURE);
-    }
+  {
+    error(0, 0, _("cannot specify times from more than one source"));
+    usage(EXIT_FAILURE);
+  }
 
   if (use_ref)
+  {
+    struct stat ref_stats;
+    /* Don't use (no_dereference?lstat:stat) (args), since stat
+       might be an object-like macro.  */
+    if (no_dereference ? lstat(ref_file, &ref_stats)
+                       : stat(ref_file, &ref_stats))
+      error(EXIT_FAILURE, errno,
+            _("failed to get attributes of %s"), quoteaf(ref_file));
+    newtime[0] = get_stat_atime(&ref_stats);
+    newtime[1] = get_stat_mtime(&ref_stats);
+    date_set = true;
+    if (flex_date)
     {
-      struct stat ref_stats;
-      /* Don't use (no_dereference?lstat:stat) (args), since stat
-         might be an object-like macro.  */
-      if (no_dereference ? lstat (ref_file, &ref_stats)
-          : stat (ref_file, &ref_stats))
-        error (EXIT_FAILURE, errno,
-               _("failed to get attributes of %s"), quoteaf (ref_file));
-      newtime[0] = get_stat_atime (&ref_stats);
-      newtime[1] = get_stat_mtime (&ref_stats);
-      date_set = true;
-      if (flex_date)
-        {
-          if (change_times & CH_ATIME)
-            newtime[0] = date_relative (flex_date, newtime[0]);
-          if (change_times & CH_MTIME)
-            newtime[1] = date_relative (flex_date, newtime[1]);
-        }
+      if (change_times & CH_ATIME)
+        newtime[0] = date_relative(flex_date, newtime[0]);
+      if (change_times & CH_MTIME)
+        newtime[1] = date_relative(flex_date, newtime[1]);
     }
+  }
   else
+  {
+    if (flex_date)
     {
-      if (flex_date)
-        {
-          struct timespec now = current_timespec ();
-          newtime[1] = newtime[0] = date_relative (flex_date, now);
-          date_set = true;
+      struct timespec now = current_timespec();
+      newtime[1] = newtime[0] = date_relative(flex_date, now);
+      date_set = true;
 
-          /* If neither -a nor -m is specified, treat "-d now" as if
-             it were absent; this lets "touch" succeed more often in
-             the presence of restrictive permissions.  */
-          if (change_times == (CH_ATIME | CH_MTIME)
-              && timespec_cmp (newtime[0], now) == 0)
-            {
-              /* Check that it really was "-d now", and not a timestamp
-                 that just happens to be the current time.  */
-              struct timespec notnow, notnow1;
-              notnow.tv_sec = now.tv_sec ^ 1;
-              notnow.tv_nsec = now.tv_nsec;
-              notnow1 = date_relative (flex_date, notnow);
-              if (timespec_cmp (notnow1, notnow) == 0)
-                date_set = false;
-            }
-        }
+      /* If neither -a nor -m is specified, treat "-d now" as if
+         it were absent; this lets "touch" succeed more often in
+         the presence of restrictive permissions.  */
+      if (change_times == (CH_ATIME | CH_MTIME) && timespec_cmp(newtime[0], now) == 0)
+      {
+        /* Check that it really was "-d now", and not a timestamp
+           that just happens to be the current time.  */
+        struct timespec notnow, notnow1;
+        notnow.tv_sec = now.tv_sec ^ 1;
+        notnow.tv_nsec = now.tv_nsec;
+        notnow1 = date_relative(flex_date, notnow);
+        if (timespec_cmp(notnow1, notnow) == 0)
+          date_set = false;
+      }
     }
+  }
 
   /* The obsolete 'MMDDhhmm[YY]' form is valid IFF there are
      two or more non-option arguments.  */
-  if (!date_set && 2 <= argc - optind && posix2_version () < 200112
-      && posixtime (&newtime[0].tv_sec, argv[optind],
-                    PDS_TRAILING_YEAR | PDS_PRE_2000))
+  if (!date_set && 2 <= argc - optind && posix2_version() < 200112 && posixtime(&newtime[0].tv_sec, argv[optind], PDS_TRAILING_YEAR | PDS_PRE_2000))
+  {
+    newtime[0].tv_nsec = 0;
+    newtime[1] = newtime[0];
+    date_set = true;
+
+    if (!getenv("POSIXLY_CORRECT"))
     {
-      newtime[0].tv_nsec = 0;
-      newtime[1] = newtime[0];
-      date_set = true;
+      struct tm const *tm = localtime(&newtime[0].tv_sec);
 
-      if (! getenv ("POSIXLY_CORRECT"))
-        {
-          struct tm const *tm = localtime (&newtime[0].tv_sec);
-
-          /* Technically, it appears that even a deliberate attempt to cause
-             the above localtime to return NULL will always fail because our
-             posixtime implementation rejects all dates for which localtime
-             would fail.  However, skip the warning if it ever fails.  */
-          if (tm)
-            error (0, 0,
-                   _("warning: 'touch %s' is obsolete; use "
-                     "'touch -t %04ld%02d%02d%02d%02d.%02d'"),
-                   argv[optind],
-                   tm->tm_year + 1900L, tm->tm_mon + 1, tm->tm_mday,
-                   tm->tm_hour, tm->tm_min, tm->tm_sec);
-        }
-
-      optind++;
+      /* Technically, it appears that even a deliberate attempt to cause
+         the above localtime to return NULL will always fail because our
+         posixtime implementation rejects all dates for which localtime
+         would fail.  However, skip the warning if it ever fails.  */
+      if (tm)
+        error(0, 0,
+              _("warning: 'touch %s' is obsolete; use "
+                "'touch -t %04ld%02d%02d%02d%02d.%02d'"),
+              argv[optind],
+              tm->tm_year + 1900L, tm->tm_mon + 1, tm->tm_mday,
+              tm->tm_hour, tm->tm_min, tm->tm_sec);
     }
+
+    optind++;
+  }
 
   if (!date_set)
-    {
-      if (change_times == (CH_ATIME | CH_MTIME))
-        amtime_now = true;
-      else
-        newtime[1].tv_nsec = newtime[0].tv_nsec = UTIME_NOW;
-    }
+  {
+    if (change_times == (CH_ATIME | CH_MTIME))
+      amtime_now = true;
+    else
+      newtime[1].tv_nsec = newtime[0].tv_nsec = UTIME_NOW;
+  }
 
   if (optind == argc)
-    {
-      error (0, 0, _("missing file operand"));
-      usage (EXIT_FAILURE);
-    }
+  {
+    error(0, 0, _("missing file operand"));
+    usage(EXIT_FAILURE);
+  }
 
   bool ok = true;
   for (; optind < argc; ++optind)
-    ok &= touch (argv[optind]);
+    ok &= touch(argv[optind]);
 
   return ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/touch/mode.sh
+++ b/tests/touch/mode.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Test touch --mode.
+# Copyright (C) 2026 Free Software Foundation, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
+print_ver_ touch
+
+# Use a restrictive but predictable umask where necessary.
+# --mode should specify the mode used when creating a new file.
+
+# Test basic creation with mode 0644.
+rm -f file || framework_failure_
+touch --mode=0644 file || fail=1
+test "$(stat -c %a file)" = 644 || fail=1
+
+
+# Test creation with executable permissions.
+rm -f file || framework_failure_
+touch --mode=0755 file || fail=1
+test "$(stat -c %a file)" = 755 || fail=1
+
+
+# Test private file permissions.
+rm -f file || framework_failure_
+touch --mode=0700 file || fail=1
+test "$(stat -c %a file)" = 700 || fail=1
+
+
+# --mode must not change permissions of an existing file.
+rm -f file || framework_failure_
+touch --mode=0600 file || fail=1
+test "$(stat -c %a file)" = 600 || fail=1
+
+touch --mode=0777 file || fail=1
+test "$(stat -c %a file)" = 600 || fail=1
+
+
+# Test that umask is honored when creating files.
+rm -f file || framework_failure_
+(
+  umask 022
+  touch --mode=0777 file
+) || fail=1
+
+test "$(stat -c %a file)" = 755 || fail=1
+
+
+# With umask 000, the requested permissions should be preserved.
+rm -f file || framework_failure_
+(
+  umask 000
+  touch --mode=0777 file
+) || fail=1
+
+test "$(stat -c %a file)" = 777 || fail=1
+
+
+# Invalid octal modes must be rejected.
+for mode in 888 hello -755 10000; do
+  rm -f file || framework_failure_
+
+  touch --mode="$mode" file 2>/dev/null && fail=1
+
+  # An invalid mode must not create the file.
+  test ! -e file || fail=1
+done
+
+
+# Normal touch behavior must remain unchanged.
+rm -f normal || framework_failure_
+touch normal || fail=1
+test -f normal || fail=1
+
+
+Exit $fail


### PR DESCRIPTION
## Summary

This PR adds a new `--mode=MODE` option to `touch`, allowing users to specify the permissions used when creating a file that does not already exist.

Example:

```sh
touch --mode=0755 script.sh
touch --mode=0600 private-file
```

## Motivation

`touch` creates an empty file when the specified file does not already exist, but currently the creation mode is fixed internally and affected by the process `umask`.

When a specific creation mode is required, users need an additional operation such as:

```sh
touch file
chmod 0755 file
```

The proposed `--mode` option allows the desired mode to be supplied directly during file creation.

## Behavior

`--mode=MODE`:

* Accepts an octal permission mode, such as `0644`, `0755`, or `0600`.
* Applies only when `touch` creates a new file.
* Remains subject to the process `umask`.
* Does **not** modify the permissions of an existing file.
* Does not change the existing behavior of `touch` when the option is omitted.

For example:

```sh
touch --mode=0600 file
touch --mode=0777 file
```

The second command updates the timestamps normally, but the existing file remains mode `0600`.

With a `0022` umask:

```sh
touch --mode=0777 file
```

creates the file with mode `0755`.

## Invalid modes

Invalid octal modes are rejected, including values such as:

```text
888
hello
-755
10000
```

## Tests

Tests have been added covering:

* Creation with different permission modes
* Existing-file behavior
* Interaction with `umask`
* Invalid mode handling
* Preservation of normal `touch` behavior

## Documentation

The `touch` documentation and `--help` output have been updated to describe the new option and clarify that the requested mode is subject to `umask`.

## Compatibility

This is an additive change. Existing `touch` invocations are unaffected.

The option intentionally applies only during file creation rather than acting as an implicit `chmod` on existing files.
