### PR TITLE
tests: echo: check that \u, \U and \" are not escapes

### DIFF
--- a/tests/misc/echo.sh
+++ b/tests/misc/echo.sh
@@ -96,4 +96,26 @@ JKLMNOJKLMNO
 EOF
 compare exp out || fail=1
 
+# echo has no \", \u or \U escape (unlike printf):
+# the backslash and the following character are output as is.
+cat <<\EOF > exp
+a\"b
+a\u0041b
+a\U00000041b
+\u
+\U0000004
+\u00zz
+\uD800
+\U00110000
+EOF
+$prog -e 'a\"b' > out || fail=1
+$prog -e 'a\u0041b' >> out || fail=1
+$prog -e 'a\U00000041b' >> out || fail=1
+$prog -e '\u' >> out || fail=1
+$prog -e '\U0000004' >> out || fail=1
+$prog -e '\u00zz' >> out || fail=1
+$prog -e '\uD800' >> out || fail=1
+$prog -e '\U00110000' >> out || fail=1
+compare exp out || fail=1
+
 Exit $fail


### PR DESCRIPTION
* tests/misc/echo.sh: Ensure 'echo -e' outputs \", \u and \U verbatim, with their backslash, as they are not escape sequences for echo (unlike printf).  Also cover truncated, non-hexadecimal, surrogate and out-of-range payloads after \u and \U.
