### PR TITLE
ls: fix --dired byte offsets with --color

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,11 @@ GNU coreutils NEWS                                    -*- outline -*-
   'head' and 'tail' now quote names in file headers when needed.
   [This bug was present in "the beginning".]
 
+  'ls --dired' now reports correct byte offsets when colors are enabled.
+  Previously the escape sequences written for colors were not counted,
+  so the reported offsets pointed before the file names.
+  [This bug was present in "the beginning".]
+
   'mv' now warns when copying extended attributes fails with ENOTSUP, e.g., when
   moving files to a file system that does not support them.
   [bug introduced in coreutils-7.3]

--- a/src/ls.c
+++ b/src/ls.c
@@ -5073,7 +5073,8 @@ get_color_indicator (const struct fileinfo *f, bool symlink_target)
   return s->string ? s : NULL;
 }
 
-/* Output a color indicator (which may contain nulls).  */
+/* Output a color indicator (which may contain nulls),
+   accounting for its bytes with --dired.  */
 static void
 put_indicator (const struct bin_str *ind)
 {
@@ -5091,6 +5092,7 @@ put_indicator (const struct bin_str *ind)
       prep_non_filename_text ();
     }
 
+  dired_pos += ind->len;
   fwrite (ind->string, ind->len, 1, stdout);
 }
 

--- a/tests/ls/dired.sh
+++ b/tests/ls/dired.sh
@@ -90,4 +90,22 @@ printf %s "$newline" > exp || framework_failure_
 compare exp actual || fail=1
 
 
+# The escape sequences emitted for --color are part of the output,
+# so they must be accounted for in the reported offsets.
+mkdir color-dir || framework_failure_
+mkdir color-dir/sub || framework_failure_
+touch color-dir/reg || framework_failure_
+LS_COLORS='no=33:di=01;34:fi=32' \
+  ls -lR --dired --color=always --quoting-style=literal color-dir > out \
+  || fail=1
+set -- $(sed -n 's|^//DIRED// ||p' out)
+test "$#" -eq 4 || framework_failure_
+for name in reg sub; do
+  dd bs=1 skip="$1" count="$(($2 - $1))" < out > actual 2>/dev/null \
+    || framework_failure_
+  printf %s "$name" > exp || framework_failure_
+  compare exp actual || fail=1
+  shift; shift
+done
+
 Exit $fail


### PR DESCRIPTION
With --color, the escape sequences written around file names were not counted, so each //DIRED// and //SUBDIRED// offset was short by the escapes output before it, and pointed inside an escape sequence rather than at the start of the file name.
Identified working on:
https://github.com/uutils/coreutils/pull/14499

* src/ls.c (put_indicator): Account for the bytes written.
* tests/ls/dired.sh: Add a test case.
* NEWS: Mention the fix.
